### PR TITLE
fix: allow Trino serviceuser to read/write secret objects

### DIFF
--- a/deploy/manifests/roles.yaml
+++ b/deploy/manifests/roles.yaml
@@ -38,6 +38,7 @@ rules:
     resources:
       - pods
       - configmaps
+      - secrets
       - services
       - endpoints
       - serviceaccounts


### PR DESCRIPTION
## Description
Trying out some demos i noticed that the Trino operator fails reading the secret with the basic user credentials for the Cluster.


```
2022-01-31T14:41:18.818012Z ERROR stackable_trino_operator: Failed to reconcile object error=reconciler for object TrinoCluster.v1alpha1.trino.stackable.tech/simple-trino.default failed error.sources=[failed to processing authentication config element from k8s, Failed to find referenced Secret.v1./simple-trino-users-secret.default, Kubernetes reported error: ApiError: secrets "simple-trino-users-secret" is forbidden: User "system:serviceaccount:default:trino-operator-serviceaccount" cannot get resource "secrets" in API group "" in the namespace "default": Forbidden (ErrorResponse { status: "Failure", message: "secrets \"simple-trino-users-secret\" is forbidden: User \"system:serviceaccount:default:trino-operator-serviceaccount\" cannot get resource \"secrets\" in API group \"\" in the namespace \"default\"", reason: "Forbidden", code: 403 }), ApiError: secrets "simple-trino-users-secret" is forbidden: User "system:serviceaccount:default:trino-operator-serviceaccount" cannot get resource "secrets" in API group "" in the namespace "default": Forbidden (ErrorResponse { status: "Failure", message: "secrets \"simple-trino-users-secret\" is forbidden: User \"system:serviceaccount:default:trino-operator-serviceaccount\" cannot get resource \"secrets\" in API group \"\" in the namespace \"default\"", reason: "Forbidden", code: 403 }), secrets "simple-trino-users-secret" is forbidden: User "system:serviceaccount:default:trino-operator-serviceaccount" cannot get resource "secrets" in API group "" in the namespace "default": Forbidden]
```
I added the needed read/write permission for secrets to the ClusterRole.

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
