### PR TITLE
[Merged by Bors] - Adapt to opa rework and support specifying a namespace to watch 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - `operator-rs` `0.10.0` -> `0.13.0` ([#149],[#157]).
-- BREAKING: The operator now writes a `ConfigMap` for Rego rules instead of the custom 
-  resource for the obsolete regorule-operator. This means that the rego rule operator
-  is not required anymore for authorization and opa-operator tag >= `0.9.0` ([#157]).
+- BREAKING: The operator now writes a `ConfigMap` for Rego rules instead of
+  the custom resource for the obsolete regorule-operator. This means that 
+  the rego rule operator is not required anymore for authorization and 
+  opa-operator tag >= `0.9.0` ([#157]).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,21 +8,21 @@ All notable changes to this project will be documented in this file.
 
 - Reconciliation errors are now reported as Kubernetes events ([#149]).
 - Use cli argument `watch-namespace` / env var `WATCH_NAMESPACE` to specify
-  a single namespace to watch ([#xxx]).
+  a single namespace to watch ([#157]).
 
 ### Changed
 
-- `operator-rs` `0.10.0` -> `0.13.0` ([#149],[#xxx]).
+- `operator-rs` `0.10.0` -> `0.13.0` ([#149],[#157]).
 - BREAKING: The operator now writes a `ConfigMap` for Rego rules instead of the custom 
   resource for the obsolete regorule-operator. This means that the rego rule operator
-  is not required anymore for authorization and opa-operator >= `0.9.0` ([#xxx]).
+  is not required anymore for authorization and opa-operator tag >= `0.9.0` ([#157]).
 
 ### Removed
 
-- `stackable-regorule-crd` dependency ([#xxx]).
+- `stackable-regorule-crd` dependency ([#157]).
 
 [#149]: https://github.com/stackabletech/trino-operator/pull/149
-[#xxx]:
+[#157]: https://github.com/stackabletech/trino-operator/pull/157
 
 ## [0.3.1] - 2022-02-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ All notable changes to this project will be documented in this file.
 
 - `operator-rs` `0.10.0` -> `0.13.0` ([#149],[#157]).
 - BREAKING: The operator now writes a `ConfigMap` for Rego rules instead of
-  the custom resource for the obsolete regorule-operator. This means that 
-  the rego rule operator is not required anymore for authorization and 
+  the custom resource for the obsolete regorule-operator. This means that
+  the rego rule operator is not required anymore for authorization and
   opa-operator tag >= `0.9.0` ([#157]).
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - `operator-rs` `0.10.0` -> `0.13.0` ([#149],[#xxx]).
-- The operator now writes a `ConfigMap` for Rego rules instead of the custom 
-  resource for the obsolete regorule-operator. ([#xxx]).
+- BREAKING: The operator now writes a `ConfigMap` for Rego rules instead of the custom 
+  resource for the obsolete regorule-operator. This means that the rego rule operator
+  is not required anymore for authorization and opa-operator >= `0.9.0` ([#xxx]).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,21 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Reconciliation errors are now reported as Kubernetes events ([#149]).
+- Use cli argument `watch-namespace` / env var `WATCH_NAMESPACE` to specify
+  a single namespace to watch ([#xxx]).
 
 ### Changed
 
-- `operator-rs` `0.10.0` -> `0.12.0` ([#149]).
-- `stackable-regorule-crd` `0.6.0` → `0.7.0` ([#149]).
+- `operator-rs` `0.10.0` -> `0.13.0` ([#149],[#xxx]).
+- The operator now writes a `ConfigMap` for Rego rules instead of the custom 
+  resource for the obsolete regorule-operator. ([#xxx]).
+
+### Removed
+
+- `stackable-regorule-crd` dependency ([#xxx]).
 
 [#149]: https://github.com/stackabletech/trino-operator/pull/149
+[#xxx]:
 
 ## [0.3.1] - 2022-02-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.14"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63edc3f163b3c71ec8aa23f9bd6070f77edbf3d1d198b164afa90ff00e4ec62"
+checksum = "5177fac1ab67102d8989464efd043c6ff44191b1557ec1ddd489b4f7e1447e77"
 dependencies = [
  "atty",
  "bitflags",
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.14"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1132dc3944b31c20dd8b906b3a9f0a5d0243e092d59171414969657ac6aa85"
+checksum = "01d42c94ce7c2252681b5fed4d3627cc807b13dfc033246bd05d5b252399000e"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -1560,8 +1560,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.12.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.12.0#ac525b91421f7b0d4c74462627bf13e59be5661b"
+version = "0.13.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.13.0#401f4053d8c32d0fcd507d94799956181f66105d"
 dependencies = [
  "backoff",
  "chrono",
@@ -1581,21 +1581,11 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "strum",
+ "strum 0.23.0",
  "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "stackable-regorule-crd"
-version = "0.7.0"
-source = "git+https://github.com/stackabletech/regorule-operator.git?tag=0.7.0#fc3e9038892d2124e4be0fd54170edee3c2b427a"
-dependencies = [
- "serde",
- "serde_json",
- "stackable-operator",
 ]
 
 [[package]]
@@ -1610,9 +1600,7 @@ dependencies = [
  "serde_yaml",
  "snafu",
  "stackable-operator",
- "stackable-regorule-crd",
- "strum",
- "strum_macros",
+ "strum 0.24.0",
  "tracing",
 ]
 
@@ -1631,9 +1619,8 @@ dependencies = [
  "serde_yaml",
  "snafu",
  "stackable-operator",
- "stackable-regorule-crd",
  "stackable-trino-crd",
- "strum",
+ "strum 0.24.0",
  "tokio",
  "tracing",
 ]
@@ -1650,7 +1637,16 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.23.1",
+]
+
+[[package]]
+name = "strum"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8"
+dependencies = [
+ "strum_macros 0.24.0",
 ]
 
 [[package]]
@@ -1660,6 +1656,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
 dependencies = [
  "heck 0.3.3",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
+dependencies = [
+ "heck 0.4.0",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,4 +1,3 @@
-* xref:building.adoc[]
 * xref:installation.adoc[]
 * xref:configuration.adoc[]
 * xref:usage.adoc[]

--- a/docs/modules/ROOT/pages/building.adoc
+++ b/docs/modules/ROOT/pages/building.adoc
@@ -1,6 +1,0 @@
-= Building the Operator
-
-This operator is written in Rust.
-It is developed against the latest stable Rust release (1.56 at the time of writing).
-
-    cargo build

--- a/docs/modules/ROOT/pages/commandline_args.adoc
+++ b/docs/modules/ROOT/pages/commandline_args.adoc
@@ -1,11 +1,28 @@
 
 === product-config
 
-*Default value*: `/etc/stackable/stackable-trino/config-spec/properties.yaml`
+*Default value*: `/etc/stackable/trino-operator/config-spec/properties.yaml`
 
 *Required*: false
 
 *Multiple values:* false
 
+[source]
+----
+cargo run -- run --product-config /foo/bar/properties.yaml
+----
 
-This file contains property definitions for the Trino configuration.
+=== watch-namespace
+
+*Default value*: All namespaces
+
+*Required*: false
+
+*Multiple values:* false
+
+The operator will **only** watch for resources in the provided namespace `test`:
+
+[source]
+----
+cargo run -- run --watch-namespace test
+----

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -1,8 +1,13 @@
 = Configuration
 
 == Command Line Parameters
+
 This operator accepts the following command line parameters:
 
 include::commandline_args.adoc[]
 
+== Environment variables
 
+This operator accepts the following environment variables:
+
+include::env_var_args.adoc[]

--- a/docs/modules/ROOT/pages/env_var_args.adoc
+++ b/docs/modules/ROOT/pages/env_var_args.adoc
@@ -1,0 +1,56 @@
+
+=== PRODUCT_CONFIG
+
+*Default value*: `/etc/stackable/trino-operator/config-spec/properties.yaml`
+
+*Required*: false
+
+*Multiple values:* false
+
+[source]
+----
+export PRODUCT_CONFIG=/foo/bar/properties.yaml
+cargo run -- run
+----
+
+or via docker:
+
+----
+docker run \
+    --name trino-operator \
+    --network host \
+    --env KUBECONFIG=/home/stackable/.kube/config \
+    --env PRODUCT_CONFIG=/my/product/config.yaml \
+    --mount type=bind,source="$HOME/.kube/config",target="/home/stackable/.kube/config" \
+    docker.stackable.tech/stackable/trino-operator:latest
+----
+
+=== WATCH_NAMESPACE
+
+*Default value*: All namespaces
+
+*Required*: false
+
+*Multiple values:* false
+
+The operator will **only** watch for resources in the provided namespace `test`:
+
+[source]
+----
+export WATCH_NAMESPACE=test
+cargo run -- run
+----
+
+or via docker:
+
+[source]
+----
+docker run \
+--name trino-operator \
+--network host \
+--env KUBECONFIG=/home/stackable/.kube/config \
+--env WATCH_NAMESPACE=test \
+--mount type=bind,source="$HOME/.kube/config",target="/home/stackable/.kube/config" \
+docker.stackable.tech/stackable/trino-operator:latest
+----
+

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -343,6 +343,7 @@ For a role or role group, at the same level of `config`, you can specify: `confi
 - `node.properties`
 - `log.properties`
 - `password-authenticator.properties`
+- `hive.properties`
 
 For a list of possible configuration properties consult the https://trino.io/docs/current/admin/properties.html[Trino Properties Reference].
 

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -8,9 +8,8 @@ Trino works together with the Apache Hive metastore and S3 bucket.
 * Accessible S3 Bucket
     ** Endpoint, access-key and secret-key
     ** Data in the Bucket (we use the https://archive.ics.uci.edu/ml/datasets/iris[Iris] dataset here)
-* A https://github.com/stackabletech/regorule-operator/blob/main/deploy/crd/regorule.crd.yaml[Rego rule CRD] even if no OPA is activated
 * Optional deployed Stackable https://github.com/stackabletech/secret-operator[Secret-Operator] for certificates when deploying for HTTPS
-* Optional for authorization: Deployed Stackable https://github.com/stackabletech/opa-operator[OPA-Operator] and https://github.com/stackabletech/regorule-operator[Regorule-Operator]
+* Optional for authorization: Deployed Stackable https://github.com/stackabletech/opa-operator[OPA-Operator]
 * Optional https://repo.stackable.tech/#browse/browse:packages:trino-cli%2Ftrino-cli-363-executable.jar[Trino CLI] to test SQL queries
 
 == Installation
@@ -64,22 +63,20 @@ The <user>:<password> combinations are provided in the `stringData` field. The h
 htpasswd -nbBC 10 admin admin
 ----
 
-=== Regorule Server (Authorization)
+=== Authorization
 
-The OPA cluster requires downloading rules from a RegoRule server. You can use your own solution or fall back on the Stackable Regorule Server
-
-Please refer to the https://github.com/stackabletech/regorule-operator[RegoRule] operator and https://docs.stackable.tech/home/index.html[docs].
-
-This is an example custom resource for the Stackable RegoRule server:
+In order to authorize Trino via OPA, a `ConfigMap` containing Rego rules for Trino has to be applied. The following example is an all access Rego rule for testing. Do not use that in production!
 
 [source,yaml]
 ----
 apiVersion: opa.stackable.tech/v1alpha1
-kind: RegoRule
+kind: ConfigMap
 metadata:
-  name: simple
-spec:
-  rego: |
+  name: opa-bundle-trino
+  labels:
+    opa.stackable.tech/bundle: "trino"
+data:
+  trino.rego: |
     package trino
 
     can_execute_query = true
@@ -104,24 +101,13 @@ spec:
 
     can_show_tables = true
 
-    default can_select_from_columns = false
-
-    can_select_from_columns {
-      input.request.table.catalog == "system"
-      input.request.table.schema == "information_schema"
-      input.request.table.table == {"tables", "schemata"}[_]
-    }
-
-    can_select_from_columns {
-      input.request.table.catalog == "hive"
-      input.request.table.schema == "iris"
-      input.request.table.table == {"iris_parquet"}[_]
-    }
+    can_select_from_columns = true
 
     can_view_query_owned_by = true
 ----
 
 You can let the Trino operator write its own Rego rules by configuring the `authorization` field in the custom resource. This is a rudimentary implementation for user access.
+
 [source,yaml]
 ----
 authorization:

--- a/rust/crd/Cargo.toml
+++ b/rust/crd/Cargo.toml
@@ -8,15 +8,13 @@ repository = "https://github.com/stackabletech/trino-operator"
 version = "0.3.2-nightly"
 
 [dependencies]
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.12.0" }
-stackable-regorule-crd = { git = "https://github.com/stackabletech/regorule-operator.git", tag = "0.7.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.13.0" }
 
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 snafu = "0.7"
-strum = "0.23"
-strum_macros = "0.23"
+strum = { version = "0.24", features = ["derive"] }
 tracing = "0.1"
 
 [dev-dependencies]

--- a/rust/crd/src/authorization.rs
+++ b/rust/crd/src/authorization.rs
@@ -5,6 +5,7 @@ use snafu::{ResultExt, Snafu};
 use stackable_operator::builder::{ConfigMapBuilder, ObjectMetaBuilder};
 use stackable_operator::client::Client;
 use stackable_operator::k8s_openapi::api::core::v1::ConfigMap;
+use stackable_operator::kube::ResourceExt;
 use stackable_operator::schemars::{self, JsonSchema};
 use std::collections::BTreeMap;
 
@@ -79,7 +80,7 @@ async fn create_or_update_rego_config_map(
         .metadata(
             ObjectMetaBuilder::new()
                 .name_and_namespace(trino)
-                .name(package_name)
+                .name(format!("{}-opa-rego-{}", trino.name(), package_name))
                 .labels(
                     [(
                         "opa.stackable.tech/bundle".to_string(),

--- a/rust/crd/src/authorization.rs
+++ b/rust/crd/src/authorization.rs
@@ -2,21 +2,23 @@ use crate::{TrinoCluster, TrinoClusterSpec};
 
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
-use stackable_operator::builder::ObjectMetaBuilder;
+use stackable_operator::builder::{ConfigMapBuilder, ObjectMetaBuilder};
 use stackable_operator::client::Client;
-use stackable_operator::kube::runtime::reflector::ObjectRef;
+use stackable_operator::k8s_openapi::api::core::v1::ConfigMap;
 use stackable_operator::schemars::{self, JsonSchema};
-use stackable_regorule_crd::{RegoRule, RegoRuleSpec};
 use std::collections::BTreeMap;
 
 const FIELD_MANAGER_SCOPE: &str = "trinocluster";
 
 #[derive(Snafu, Debug)]
 pub enum Error {
-    #[snafu(display("failed to apply rego rule {rego}"))]
-    RegoRuleApply {
+    #[snafu(display("failed to build rego rule config map"))]
+    FailedRegoRuleConfigMapBuild {
         source: stackable_operator::error::Error,
-        rego: ObjectRef<RegoRule>,
+    },
+    #[snafu(display("failed to apply rego rule config map"))]
+    FailedRegoRuleConfigMapApply {
+        source: stackable_operator::error::Error,
     },
     #[snafu(display("object is missing metadata to build owner reference"))]
     ObjectMissingMetadataForOwnerRef {
@@ -57,35 +59,47 @@ pub async fn create_rego_rules(client: &Client, trino: &TrinoCluster) -> Result<
 
     if let Some(authorization) = &spec.authorization {
         let rego_rules = build_rego_rules(authorization)?;
-        create_or_update_rego_rule_resource(client, trino, &authorization.package, rego_rules)
-            .await?;
+        create_or_update_rego_config_map(client, trino, &authorization.package, rego_rules).await?;
     }
 
     Ok(())
 }
 
-async fn create_or_update_rego_rule_resource(
+async fn create_or_update_rego_config_map(
     client: &Client,
     trino: &TrinoCluster,
     package_name: &str,
     rego_rules: String,
-) -> Result<RegoRule> {
-    let obj = RegoRule {
-        metadata: ObjectMetaBuilder::new()
-            .name_and_namespace(trino)
-            .name(package_name)
-            .ownerreference_from_resource(trino, None, Some(true))
-            .context(ObjectMissingMetadataForOwnerRefSnafu)?
-            .build(),
-        spec: RegoRuleSpec { rego: rego_rules },
-    };
+) -> Result<ConfigMap> {
+    let config_map_data = [(format!("{}.rego", package_name), rego_rules)]
+        .into_iter()
+        .collect::<BTreeMap<_, _>>();
+
+    let config_map = ConfigMapBuilder::new()
+        .metadata(
+            ObjectMetaBuilder::new()
+                .name_and_namespace(trino)
+                .name(package_name)
+                .labels(
+                    [(
+                        "opa.stackable.tech/bundle".to_string(),
+                        package_name.to_string(),
+                    )]
+                    .into_iter()
+                    .collect::<BTreeMap<_, _>>(),
+                )
+                .ownerreference_from_resource(trino, None, Some(true))
+                .context(ObjectMissingMetadataForOwnerRefSnafu)?
+                .build(),
+        )
+        .data(config_map_data)
+        .build()
+        .context(FailedRegoRuleConfigMapBuildSnafu)?;
 
     client
-        .apply_patch(FIELD_MANAGER_SCOPE, &obj, &obj)
+        .apply_patch(FIELD_MANAGER_SCOPE, &config_map, &config_map)
         .await
-        .with_context(|_| RegoRuleApplySnafu {
-            rego: ObjectRef::from_obj(&obj),
-        })
+        .context(FailedRegoRuleConfigMapApplySnafu)
 }
 
 fn build_rego_rules(authorization_rules: &Authorization) -> Result<String> {

--- a/rust/crd/src/discovery.rs
+++ b/rust/crd/src/discovery.rs
@@ -1,7 +1,5 @@
 use crate::{HTTPS_PORT, HTTP_PORT};
 
-use strum_macros::Display;
-
 /// Reference to a single `Pod` that is a component of a [`crate::TrinoCluster`]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TrinoPodRef {
@@ -43,7 +41,7 @@ impl TrinoDiscovery {
     }
 }
 
-#[derive(Clone, Debug, Display, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, strum::Display, Eq, Hash, PartialEq)]
 pub enum TrinoDiscoveryProtocol {
     #[strum(serialize = "http")]
     Http,

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -18,8 +18,7 @@ use stackable_operator::schemars::{self, JsonSchema};
 use std::collections::BTreeMap;
 use std::str::FromStr;
 use strum::IntoEnumIterator;
-use strum_macros::Display;
-use strum_macros::EnumIter;
+use strum::{Display, EnumIter};
 
 pub const APP_NAME: &str = "trino";
 pub const FIELD_MANAGER_SCOPE: &str = "trinocluster";

--- a/rust/operator-binary/Cargo.toml
+++ b/rust/operator-binary/Cargo.toml
@@ -9,12 +9,11 @@ repository = "https://github.com/stackabletech/trino-operator"
 version = "0.3.2-nightly"
 
 [dependencies]
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.12.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.13.0" }
 stackable-trino-crd = { path = "../crd" }
-stackable-regorule-crd = { git = "https://github.com/stackabletech/regorule-operator.git", tag = "0.7.0" }
 
 anyhow = "1.0"
-clap = "3.0"
+clap = "3.1"
 futures = { version = "0.3", features = ["compat"] }
 pin-project = "1.0"
 semver = "1.0"
@@ -22,11 +21,11 @@ serde = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.8"
 snafu = "0.7"
-strum = { version = "0.23", features = ["derive"] }
+strum = { version = "0.24", features = ["derive"] }
 tokio = { version = "1.17", features = ["full"] }
 tracing = "0.1"
 
 [build-dependencies]
 built = { version =  "0.5", features = ["chrono", "git2"] }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.12.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.13.0" }
 stackable-trino-crd = { path = "../crd" }

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -2,6 +2,7 @@ mod controller;
 
 use clap::Parser;
 use futures::stream::StreamExt;
+use stackable_operator::cli::ProductOperatorRun;
 use stackable_operator::{
     cli::Command,
     k8s_openapi::api::{
@@ -15,7 +16,6 @@ use stackable_operator::{
     },
     logging::controller::report_controller_reconciled,
 };
-use stackable_regorule_crd::RegoRule;
 use stackable_trino_crd::TrinoCluster;
 
 mod built_info {
@@ -36,7 +36,10 @@ async fn main() -> anyhow::Result<()> {
     let opts = Opts::parse();
     match opts.cmd {
         Command::Crd => println!("{}", serde_yaml::to_string(&TrinoCluster::crd())?,),
-        Command::Run(product_config) => {
+        Command::Run(ProductOperatorRun {
+            product_config,
+            watch_namespace,
+        }) => {
             stackable_operator::utils::print_startup_string(
                 built_info::PKG_DESCRIPTION,
                 built_info::PKG_VERSION,
@@ -45,7 +48,7 @@ async fn main() -> anyhow::Result<()> {
                 built_info::BUILT_TIME_UTC,
                 built_info::RUSTC_VERSION,
             );
-            let product_config = product_config.product_config.load(&[
+            let product_config = product_config.load(&[
                 "deploy/config-spec/properties.yaml",
                 "/etc/stackable/trino-operator/config-spec/properties.yaml",
             ])?;
@@ -54,29 +57,36 @@ async fn main() -> anyhow::Result<()> {
                 stackable_operator::client::create_client(Some("trino.stackable.tech".to_string()))
                     .await?;
 
-            Controller::new(client.get_all_api::<TrinoCluster>(), ListParams::default())
-                .owns(client.get_all_api::<Service>(), ListParams::default())
-                .owns(client.get_all_api::<StatefulSet>(), ListParams::default())
-                .owns(client.get_all_api::<ConfigMap>(), ListParams::default())
-                .owns(client.get_all_api::<RegoRule>(), ListParams::default())
-                .shutdown_on_signal()
-                .run(
-                    controller::reconcile_trino,
-                    controller::error_policy,
-                    Context::new(controller::Ctx {
-                        client: client.clone(),
-                        product_config,
-                    }),
-                )
-                .map(|res| {
-                    report_controller_reconciled(
-                        &client,
-                        "trinoclusters.trino.stackable.tech",
-                        &res,
-                    )
-                })
-                .collect::<()>()
-                .await;
+            Controller::new(
+                watch_namespace.get_api::<TrinoCluster>(&client),
+                ListParams::default(),
+            )
+            .owns(
+                watch_namespace.get_api::<Service>(&client),
+                ListParams::default(),
+            )
+            .owns(
+                watch_namespace.get_api::<StatefulSet>(&client),
+                ListParams::default(),
+            )
+            .owns(
+                watch_namespace.get_api::<ConfigMap>(&client),
+                ListParams::default(),
+            )
+            .shutdown_on_signal()
+            .run(
+                controller::reconcile_trino,
+                controller::error_policy,
+                Context::new(controller::Ctx {
+                    client: client.clone(),
+                    product_config,
+                }),
+            )
+            .map(|res| {
+                report_controller_reconciled(&client, "trinoclusters.trino.stackable.tech", &res)
+            })
+            .collect::<()>()
+            .await;
         }
     }
 


### PR DESCRIPTION
## Description

This PR addresses two issues.

### OPA rework

This is a `BREAKING` change. It will only work with opa-operator tag `0.9.0` or higher. The regorule operator is not required anymore since OPA does the bundeling via configmaps. 

Trino now writes a config maps (which are read by opa) for authorization instead of the regorule-operator custom resource.

fixes https://github.com/stackabletech/trino-operator/issues/156

### Specify a namespace to watch

try
```
cargo run -- run --watch-namespace test
```
or
```
export WATCH_NAMESPACE=test
cargo run -- run
```

fixes https://github.com/stackabletech/trino-operator/issues/137

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
