### PR TITLE
[Merged by Bors] - Users cannot read from tables they are not authorized anymore

### DIFF
--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -211,16 +211,13 @@ spec:
           iris_parquet:
             read: true
             write: true
-          iris_csv:
-            read: true
-            write: true
       bob:
         schemas:
-          read: false
+          read: true
           write: false
         tables:
           iris_parquet:
-            read: true
+            read: false
   s3:
     endPoint: changeme
     accessKey: changeme

--- a/examples/simple-trino-cluster-authentication-opa-authorization.yaml
+++ b/examples/simple-trino-cluster-authentication-opa-authorization.yaml
@@ -77,16 +77,13 @@ spec:
           iris_parquet:
             read: true
             write: true
-          iris_csv:
-            read: true
-            write: true
       bob:
         schemas:
-          read: false
+          read: true
           write: false
         tables:
           iris_parquet:
-            read: true
+            read: false
   s3:
     endPoint: changeme
     accessKey: changeme

--- a/rust/crd/src/authorization.rs
+++ b/rust/crd/src/authorization.rs
@@ -187,6 +187,7 @@ fn build_main_rego_rules() -> String {
     default can_select_from_columns = false
     can_select_from_columns {
         is_valid_user
+        can_access_table
     }
     
     default can_view_query_owned_by = false


### PR DESCRIPTION
## Description

In the demo today, Bob could read the `taxi_csv` table even if he was not authorized for it.

Some investigation showed which rules are evaluated when running a select on that table:
```
opa {"client_addr":"10.244.1.9:56484","level":"info","msg":"Received request.","req_id":1280,"req_method":"POST","req_path":"/v1/data/trino/can_execute_query","time":"2022-03-02T1
opa {"client_addr":"10.244.1.9:56484","level":"info","msg":"Sent response.","req_id":1280,"req_method":"POST","req_path":"/v1/data/trino/can_execute_query","resp_bytes":15,"resp_d
opa {"client_addr":"10.244.1.9:56484","level":"info","msg":"Received request.","req_id":1281,"req_method":"POST","req_path":"/v1/data/trino/can_access_catalog","time":"2022-03-02T
opa {"client_addr":"10.244.1.9:56484","level":"info","msg":"Sent response.","req_id":1281,"req_method":"POST","req_path":"/v1/data/trino/can_access_catalog","resp_bytes":15,"resp_
opa {"client_addr":"10.244.1.9:56484","level":"info","msg":"Received request.","req_id":1282,"req_method":"POST","req_path":"/v1/data/trino/can_select_from_columns","time":"2022-0
opa {"client_addr":"10.244.1.9:56484","level":"info","msg":"Sent response.","req_id":1282,"req_method":"POST","req_path":"/v1/data/trino/can_select_from_columns","resp_bytes":16,"
```
which are `can_execute_query`, `can_access_catalog` and `can_select_from_columns`. These were all true since for them the only check was if it is a valid user doing that request.

I expected that `can_access_table` will be queried, which would have prevented that, but is it not the case.

Now this is just a quick fix to make it work in demos by adding `can_access_table` to `can_select_from_columns`:
```
can_select_from_columns {
  is_valid_user
  can_access_table
}
```
@teozkr is this behavior expected from the authorizer?

The prepared rego rule playground: https://play.openpolicyagent.org/p/8k3V3Gbt8p

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
