### PR TITLE
[Merged by Bors] - Removed the tips section from usage docs

### DIFF
--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -352,8 +352,3 @@ workers:
 ----
 
 Here too, overriding properties such as `http-server.https.port` will lead to broken installations.
-
-== Tips
-
-- If you work with opa, try changing some RegoRule entries to false and see if you are not allowed to e.g. list tables or schemas.
-- When changing the automatically generated rego rule package name, a restart of the coordinator pod is required.


### PR DESCRIPTION
## Description

- Removed tips section from docs that related to the old OPA authorizer and trino creating rego rules.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
