### PR TITLE
[Merged by Bors] - test: Increase timeout for MinIO installation

### DIFF
--- a/tests/templates/kuttl/smoke/00-install-minio.yaml
+++ b/tests/templates/kuttl/smoke/00-install-minio.yaml
@@ -1,11 +1,9 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 300
 commands:
   - script: >-
-      helm upgrade test-minio
-      --install
+      helm install test-minio
       --namespace $NAMESPACE
       --set mode=standalone
       --set replicas=1
@@ -14,3 +12,4 @@ commands:
       --set users[0].accessKey=minio-access-key,users[0].secretKey=minio-secret-key,users[0].policy=readwrite
       --set resources.requests.memory=1Gi
       --repo https://charts.min.io/ minio
+    timeout: 600


### PR DESCRIPTION
# Description

Aligned with https://github.com/stackabletech/hive-operator/pull/191

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
