### PR TITLE
[Merged by Bors] - Implement resource requests and limits for Trino pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Add support for connecting to HDFS ([#263]).
 - Add support for Hive 3.1.3 ([#243]).
+- PVCs for data storage, cpu and memory limits are now configurable ([#270]).
 
 ### Changed
 
@@ -29,6 +30,7 @@ All notable changes to this project will be documented in this file.
 [#243]: https://github.com/stackabletech/trino-operator/pull/243
 [#244]: https://github.com/stackabletech/trino-operator/pull/244
 [#263]: https://github.com/stackabletech/trino-operator/pull/263
+[#270]: https://github.com/stackabletech/trino-operator/pull/270
 
 ## [0.4.0] - 2022-06-30
 

--- a/deploy/crd/trinocluster.crd.yaml
+++ b/deploy/crd/trinocluster.crd.yaml
@@ -132,6 +132,79 @@ spec:
                         queryMaxMemoryPerNode:
                           nullable: true
                           type: string
+                        resources:
+                          nullable: true
+                          properties:
+                            cpu:
+                              default:
+                                min: ~
+                                max: ~
+                              properties:
+                                max:
+                                  description: "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n<quantity>        ::= <signedNumber><suffix>\n  (Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber>\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation."
+                                  nullable: true
+                                  type: string
+                                min:
+                                  description: "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n<quantity>        ::= <signedNumber><suffix>\n  (Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber>\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation."
+                                  nullable: true
+                                  type: string
+                              type: object
+                            memory:
+                              properties:
+                                limit:
+                                  description: "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n<quantity>        ::= <signedNumber><suffix>\n  (Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber>\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation."
+                                  nullable: true
+                                  type: string
+                                runtimeLimits:
+                                  type: object
+                              type: object
+                            storage:
+                              properties:
+                                data:
+                                  default:
+                                    capacity: ~
+                                  properties:
+                                    capacity:
+                                      description: "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n<quantity>        ::= <signedNumber><suffix>\n  (Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber>\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation."
+                                      nullable: true
+                                      type: string
+                                    selectors:
+                                      description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                                      nullable: true
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values."
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist."
+                                                type: string
+                                              values:
+                                                description: "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch."
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed."
+                                          type: object
+                                      type: object
+                                    storageClass:
+                                      nullable: true
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
                       type: object
                     configOverrides:
                       additionalProperties:
@@ -165,6 +238,79 @@ spec:
                               queryMaxMemoryPerNode:
                                 nullable: true
                                 type: string
+                              resources:
+                                nullable: true
+                                properties:
+                                  cpu:
+                                    default:
+                                      min: ~
+                                      max: ~
+                                    properties:
+                                      max:
+                                        description: "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n<quantity>        ::= <signedNumber><suffix>\n  (Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber>\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation."
+                                        nullable: true
+                                        type: string
+                                      min:
+                                        description: "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n<quantity>        ::= <signedNumber><suffix>\n  (Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber>\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation."
+                                        nullable: true
+                                        type: string
+                                    type: object
+                                  memory:
+                                    properties:
+                                      limit:
+                                        description: "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n<quantity>        ::= <signedNumber><suffix>\n  (Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber>\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation."
+                                        nullable: true
+                                        type: string
+                                      runtimeLimits:
+                                        type: object
+                                    type: object
+                                  storage:
+                                    properties:
+                                      data:
+                                        default:
+                                          capacity: ~
+                                        properties:
+                                          capacity:
+                                            description: "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n<quantity>        ::= <signedNumber><suffix>\n  (Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber>\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation."
+                                            nullable: true
+                                            type: string
+                                          selectors:
+                                            description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                                            nullable: true
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                items:
+                                                  description: "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values."
+                                                  properties:
+                                                    key:
+                                                      description: key is the label key that the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist."
+                                                      type: string
+                                                    values:
+                                                      description: "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch."
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed."
+                                                type: object
+                                            type: object
+                                          storageClass:
+                                            nullable: true
+                                            type: string
+                                        type: object
+                                    type: object
+                                type: object
                             type: object
                           configOverrides:
                             additionalProperties:
@@ -260,6 +406,79 @@ spec:
                         queryMaxMemoryPerNode:
                           nullable: true
                           type: string
+                        resources:
+                          nullable: true
+                          properties:
+                            cpu:
+                              default:
+                                min: ~
+                                max: ~
+                              properties:
+                                max:
+                                  description: "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n<quantity>        ::= <signedNumber><suffix>\n  (Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber>\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation."
+                                  nullable: true
+                                  type: string
+                                min:
+                                  description: "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n<quantity>        ::= <signedNumber><suffix>\n  (Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber>\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation."
+                                  nullable: true
+                                  type: string
+                              type: object
+                            memory:
+                              properties:
+                                limit:
+                                  description: "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n<quantity>        ::= <signedNumber><suffix>\n  (Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber>\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation."
+                                  nullable: true
+                                  type: string
+                                runtimeLimits:
+                                  type: object
+                              type: object
+                            storage:
+                              properties:
+                                data:
+                                  default:
+                                    capacity: ~
+                                  properties:
+                                    capacity:
+                                      description: "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n<quantity>        ::= <signedNumber><suffix>\n  (Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber>\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation."
+                                      nullable: true
+                                      type: string
+                                    selectors:
+                                      description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                                      nullable: true
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values."
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist."
+                                                type: string
+                                              values:
+                                                description: "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch."
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed."
+                                          type: object
+                                      type: object
+                                    storageClass:
+                                      nullable: true
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
                       type: object
                     configOverrides:
                       additionalProperties:
@@ -293,6 +512,79 @@ spec:
                               queryMaxMemoryPerNode:
                                 nullable: true
                                 type: string
+                              resources:
+                                nullable: true
+                                properties:
+                                  cpu:
+                                    default:
+                                      min: ~
+                                      max: ~
+                                    properties:
+                                      max:
+                                        description: "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n<quantity>        ::= <signedNumber><suffix>\n  (Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber>\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation."
+                                        nullable: true
+                                        type: string
+                                      min:
+                                        description: "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n<quantity>        ::= <signedNumber><suffix>\n  (Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber>\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation."
+                                        nullable: true
+                                        type: string
+                                    type: object
+                                  memory:
+                                    properties:
+                                      limit:
+                                        description: "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n<quantity>        ::= <signedNumber><suffix>\n  (Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber>\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation."
+                                        nullable: true
+                                        type: string
+                                      runtimeLimits:
+                                        type: object
+                                    type: object
+                                  storage:
+                                    properties:
+                                      data:
+                                        default:
+                                          capacity: ~
+                                        properties:
+                                          capacity:
+                                            description: "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n<quantity>        ::= <signedNumber><suffix>\n  (Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber>\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation."
+                                            nullable: true
+                                            type: string
+                                          selectors:
+                                            description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                                            nullable: true
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                items:
+                                                  description: "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values."
+                                                  properties:
+                                                    key:
+                                                      description: key is the label key that the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist."
+                                                      type: string
+                                                    values:
+                                                      description: "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch."
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed."
+                                                type: object
+                                            type: object
+                                          storageClass:
+                                            nullable: true
+                                            type: string
+                                        type: object
+                                    type: object
+                                type: object
                             type: object
                           configOverrides:
                             additionalProperties:

--- a/deploy/helm/trino-operator/crds/crds.yaml
+++ b/deploy/helm/trino-operator/crds/crds.yaml
@@ -133,6 +133,203 @@ spec:
                         queryMaxMemoryPerNode:
                           nullable: true
                           type: string
+                        resources:
+                          nullable: true
+                          properties:
+                            cpu:
+                              default:
+                                min: null
+                                max: null
+                              properties:
+                                max:
+                                  description: |-
+                                    Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                    The serialization format is:
+
+                                    <quantity>        ::= <signedNumber><suffix>
+                                      (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                    <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                      (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                    <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                      (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                    <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                    No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                    When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                    Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                      a. No precision is lost
+                                      b. No fractional digits will be emitted
+                                      c. The exponent (or suffix) is as large as possible.
+                                    The sign will be omitted unless the number is negative.
+
+                                    Examples:
+                                      1.5 will be serialized as "1500m"
+                                      1.5Gi will be serialized as "1536Mi"
+
+                                    Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                    Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                    This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                  nullable: true
+                                  type: string
+                                min:
+                                  description: |-
+                                    Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                    The serialization format is:
+
+                                    <quantity>        ::= <signedNumber><suffix>
+                                      (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                    <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                      (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                    <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                      (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                    <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                    No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                    When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                    Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                      a. No precision is lost
+                                      b. No fractional digits will be emitted
+                                      c. The exponent (or suffix) is as large as possible.
+                                    The sign will be omitted unless the number is negative.
+
+                                    Examples:
+                                      1.5 will be serialized as "1500m"
+                                      1.5Gi will be serialized as "1536Mi"
+
+                                    Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                    Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                    This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                  nullable: true
+                                  type: string
+                              type: object
+                            memory:
+                              properties:
+                                limit:
+                                  description: |-
+                                    Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                    The serialization format is:
+
+                                    <quantity>        ::= <signedNumber><suffix>
+                                      (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                    <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                      (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                    <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                      (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                    <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                    No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                    When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                    Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                      a. No precision is lost
+                                      b. No fractional digits will be emitted
+                                      c. The exponent (or suffix) is as large as possible.
+                                    The sign will be omitted unless the number is negative.
+
+                                    Examples:
+                                      1.5 will be serialized as "1500m"
+                                      1.5Gi will be serialized as "1536Mi"
+
+                                    Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                    Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                    This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                  nullable: true
+                                  type: string
+                                runtimeLimits:
+                                  type: object
+                              type: object
+                            storage:
+                              properties:
+                                data:
+                                  default:
+                                    capacity: null
+                                  properties:
+                                    capacity:
+                                      description: |-
+                                        Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                        The serialization format is:
+
+                                        <quantity>        ::= <signedNumber><suffix>
+                                          (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                        <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                          (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                        <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                          (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                        <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                        No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                        When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                        Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                          a. No precision is lost
+                                          b. No fractional digits will be emitted
+                                          c. The exponent (or suffix) is as large as possible.
+                                        The sign will be omitted unless the number is negative.
+
+                                        Examples:
+                                          1.5 will be serialized as "1500m"
+                                          1.5Gi will be serialized as "1536Mi"
+
+                                        Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                        Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                        This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                      nullable: true
+                                      type: string
+                                    selectors:
+                                      description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                                      nullable: true
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    storageClass:
+                                      nullable: true
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
                       type: object
                     configOverrides:
                       additionalProperties:
@@ -166,6 +363,203 @@ spec:
                               queryMaxMemoryPerNode:
                                 nullable: true
                                 type: string
+                              resources:
+                                nullable: true
+                                properties:
+                                  cpu:
+                                    default:
+                                      min: null
+                                      max: null
+                                    properties:
+                                      max:
+                                        description: |-
+                                          Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                          The serialization format is:
+
+                                          <quantity>        ::= <signedNumber><suffix>
+                                            (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                          <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                            (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                          <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                            (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                          <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                          No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                          When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                          Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                            a. No precision is lost
+                                            b. No fractional digits will be emitted
+                                            c. The exponent (or suffix) is as large as possible.
+                                          The sign will be omitted unless the number is negative.
+
+                                          Examples:
+                                            1.5 will be serialized as "1500m"
+                                            1.5Gi will be serialized as "1536Mi"
+
+                                          Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                          Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                          This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                        nullable: true
+                                        type: string
+                                      min:
+                                        description: |-
+                                          Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                          The serialization format is:
+
+                                          <quantity>        ::= <signedNumber><suffix>
+                                            (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                          <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                            (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                          <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                            (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                          <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                          No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                          When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                          Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                            a. No precision is lost
+                                            b. No fractional digits will be emitted
+                                            c. The exponent (or suffix) is as large as possible.
+                                          The sign will be omitted unless the number is negative.
+
+                                          Examples:
+                                            1.5 will be serialized as "1500m"
+                                            1.5Gi will be serialized as "1536Mi"
+
+                                          Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                          Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                          This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                        nullable: true
+                                        type: string
+                                    type: object
+                                  memory:
+                                    properties:
+                                      limit:
+                                        description: |-
+                                          Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                          The serialization format is:
+
+                                          <quantity>        ::= <signedNumber><suffix>
+                                            (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                          <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                            (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                          <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                            (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                          <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                          No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                          When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                          Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                            a. No precision is lost
+                                            b. No fractional digits will be emitted
+                                            c. The exponent (or suffix) is as large as possible.
+                                          The sign will be omitted unless the number is negative.
+
+                                          Examples:
+                                            1.5 will be serialized as "1500m"
+                                            1.5Gi will be serialized as "1536Mi"
+
+                                          Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                          Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                          This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                        nullable: true
+                                        type: string
+                                      runtimeLimits:
+                                        type: object
+                                    type: object
+                                  storage:
+                                    properties:
+                                      data:
+                                        default:
+                                          capacity: null
+                                        properties:
+                                          capacity:
+                                            description: |-
+                                              Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                              The serialization format is:
+
+                                              <quantity>        ::= <signedNumber><suffix>
+                                                (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                              <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                                (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                              <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                                (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                              <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                              No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                              When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                              Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                                a. No precision is lost
+                                                b. No fractional digits will be emitted
+                                                c. The exponent (or suffix) is as large as possible.
+                                              The sign will be omitted unless the number is negative.
+
+                                              Examples:
+                                                1.5 will be serialized as "1500m"
+                                                1.5Gi will be serialized as "1536Mi"
+
+                                              Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                              Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                              This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                            nullable: true
+                                            type: string
+                                          selectors:
+                                            description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                                            nullable: true
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label key that the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                          storageClass:
+                                            nullable: true
+                                            type: string
+                                        type: object
+                                    type: object
+                                type: object
                             type: object
                           configOverrides:
                             additionalProperties:
@@ -261,6 +655,203 @@ spec:
                         queryMaxMemoryPerNode:
                           nullable: true
                           type: string
+                        resources:
+                          nullable: true
+                          properties:
+                            cpu:
+                              default:
+                                min: null
+                                max: null
+                              properties:
+                                max:
+                                  description: |-
+                                    Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                    The serialization format is:
+
+                                    <quantity>        ::= <signedNumber><suffix>
+                                      (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                    <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                      (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                    <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                      (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                    <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                    No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                    When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                    Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                      a. No precision is lost
+                                      b. No fractional digits will be emitted
+                                      c. The exponent (or suffix) is as large as possible.
+                                    The sign will be omitted unless the number is negative.
+
+                                    Examples:
+                                      1.5 will be serialized as "1500m"
+                                      1.5Gi will be serialized as "1536Mi"
+
+                                    Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                    Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                    This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                  nullable: true
+                                  type: string
+                                min:
+                                  description: |-
+                                    Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                    The serialization format is:
+
+                                    <quantity>        ::= <signedNumber><suffix>
+                                      (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                    <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                      (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                    <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                      (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                    <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                    No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                    When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                    Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                      a. No precision is lost
+                                      b. No fractional digits will be emitted
+                                      c. The exponent (or suffix) is as large as possible.
+                                    The sign will be omitted unless the number is negative.
+
+                                    Examples:
+                                      1.5 will be serialized as "1500m"
+                                      1.5Gi will be serialized as "1536Mi"
+
+                                    Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                    Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                    This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                  nullable: true
+                                  type: string
+                              type: object
+                            memory:
+                              properties:
+                                limit:
+                                  description: |-
+                                    Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                    The serialization format is:
+
+                                    <quantity>        ::= <signedNumber><suffix>
+                                      (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                    <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                      (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                    <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                      (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                    <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                    No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                    When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                    Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                      a. No precision is lost
+                                      b. No fractional digits will be emitted
+                                      c. The exponent (or suffix) is as large as possible.
+                                    The sign will be omitted unless the number is negative.
+
+                                    Examples:
+                                      1.5 will be serialized as "1500m"
+                                      1.5Gi will be serialized as "1536Mi"
+
+                                    Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                    Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                    This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                  nullable: true
+                                  type: string
+                                runtimeLimits:
+                                  type: object
+                              type: object
+                            storage:
+                              properties:
+                                data:
+                                  default:
+                                    capacity: null
+                                  properties:
+                                    capacity:
+                                      description: |-
+                                        Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                        The serialization format is:
+
+                                        <quantity>        ::= <signedNumber><suffix>
+                                          (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                        <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                          (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                        <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                          (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                        <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                        No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                        When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                        Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                          a. No precision is lost
+                                          b. No fractional digits will be emitted
+                                          c. The exponent (or suffix) is as large as possible.
+                                        The sign will be omitted unless the number is negative.
+
+                                        Examples:
+                                          1.5 will be serialized as "1500m"
+                                          1.5Gi will be serialized as "1536Mi"
+
+                                        Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                        Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                        This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                      nullable: true
+                                      type: string
+                                    selectors:
+                                      description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                                      nullable: true
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    storageClass:
+                                      nullable: true
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
                       type: object
                     configOverrides:
                       additionalProperties:
@@ -294,6 +885,203 @@ spec:
                               queryMaxMemoryPerNode:
                                 nullable: true
                                 type: string
+                              resources:
+                                nullable: true
+                                properties:
+                                  cpu:
+                                    default:
+                                      min: null
+                                      max: null
+                                    properties:
+                                      max:
+                                        description: |-
+                                          Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                          The serialization format is:
+
+                                          <quantity>        ::= <signedNumber><suffix>
+                                            (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                          <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                            (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                          <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                            (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                          <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                          No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                          When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                          Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                            a. No precision is lost
+                                            b. No fractional digits will be emitted
+                                            c. The exponent (or suffix) is as large as possible.
+                                          The sign will be omitted unless the number is negative.
+
+                                          Examples:
+                                            1.5 will be serialized as "1500m"
+                                            1.5Gi will be serialized as "1536Mi"
+
+                                          Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                          Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                          This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                        nullable: true
+                                        type: string
+                                      min:
+                                        description: |-
+                                          Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                          The serialization format is:
+
+                                          <quantity>        ::= <signedNumber><suffix>
+                                            (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                          <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                            (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                          <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                            (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                          <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                          No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                          When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                          Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                            a. No precision is lost
+                                            b. No fractional digits will be emitted
+                                            c. The exponent (or suffix) is as large as possible.
+                                          The sign will be omitted unless the number is negative.
+
+                                          Examples:
+                                            1.5 will be serialized as "1500m"
+                                            1.5Gi will be serialized as "1536Mi"
+
+                                          Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                          Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                          This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                        nullable: true
+                                        type: string
+                                    type: object
+                                  memory:
+                                    properties:
+                                      limit:
+                                        description: |-
+                                          Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                          The serialization format is:
+
+                                          <quantity>        ::= <signedNumber><suffix>
+                                            (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                          <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                            (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                          <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                            (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                          <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                          No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                          When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                          Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                            a. No precision is lost
+                                            b. No fractional digits will be emitted
+                                            c. The exponent (or suffix) is as large as possible.
+                                          The sign will be omitted unless the number is negative.
+
+                                          Examples:
+                                            1.5 will be serialized as "1500m"
+                                            1.5Gi will be serialized as "1536Mi"
+
+                                          Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                          Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                          This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                        nullable: true
+                                        type: string
+                                      runtimeLimits:
+                                        type: object
+                                    type: object
+                                  storage:
+                                    properties:
+                                      data:
+                                        default:
+                                          capacity: null
+                                        properties:
+                                          capacity:
+                                            description: |-
+                                              Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                              The serialization format is:
+
+                                              <quantity>        ::= <signedNumber><suffix>
+                                                (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                              <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                                (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                              <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                                (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                              <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                              No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                              When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                              Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                                a. No precision is lost
+                                                b. No fractional digits will be emitted
+                                                c. The exponent (or suffix) is as large as possible.
+                                              The sign will be omitted unless the number is negative.
+
+                                              Examples:
+                                                1.5 will be serialized as "1500m"
+                                                1.5Gi will be serialized as "1536Mi"
+
+                                              Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                              Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                              This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                            nullable: true
+                                            type: string
+                                          selectors:
+                                            description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                                            nullable: true
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label key that the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                          storageClass:
+                                            nullable: true
+                                            type: string
+                                        type: object
+                                    type: object
+                                type: object
                             type: object
                           configOverrides:
                             additionalProperties:

--- a/deploy/manifests/crds.yaml
+++ b/deploy/manifests/crds.yaml
@@ -134,6 +134,203 @@ spec:
                         queryMaxMemoryPerNode:
                           nullable: true
                           type: string
+                        resources:
+                          nullable: true
+                          properties:
+                            cpu:
+                              default:
+                                min: null
+                                max: null
+                              properties:
+                                max:
+                                  description: |-
+                                    Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                    The serialization format is:
+
+                                    <quantity>        ::= <signedNumber><suffix>
+                                      (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                    <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                      (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                    <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                      (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                    <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                    No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                    When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                    Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                      a. No precision is lost
+                                      b. No fractional digits will be emitted
+                                      c. The exponent (or suffix) is as large as possible.
+                                    The sign will be omitted unless the number is negative.
+
+                                    Examples:
+                                      1.5 will be serialized as "1500m"
+                                      1.5Gi will be serialized as "1536Mi"
+
+                                    Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                    Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                    This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                  nullable: true
+                                  type: string
+                                min:
+                                  description: |-
+                                    Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                    The serialization format is:
+
+                                    <quantity>        ::= <signedNumber><suffix>
+                                      (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                    <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                      (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                    <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                      (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                    <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                    No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                    When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                    Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                      a. No precision is lost
+                                      b. No fractional digits will be emitted
+                                      c. The exponent (or suffix) is as large as possible.
+                                    The sign will be omitted unless the number is negative.
+
+                                    Examples:
+                                      1.5 will be serialized as "1500m"
+                                      1.5Gi will be serialized as "1536Mi"
+
+                                    Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                    Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                    This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                  nullable: true
+                                  type: string
+                              type: object
+                            memory:
+                              properties:
+                                limit:
+                                  description: |-
+                                    Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                    The serialization format is:
+
+                                    <quantity>        ::= <signedNumber><suffix>
+                                      (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                    <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                      (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                    <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                      (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                    <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                    No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                    When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                    Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                      a. No precision is lost
+                                      b. No fractional digits will be emitted
+                                      c. The exponent (or suffix) is as large as possible.
+                                    The sign will be omitted unless the number is negative.
+
+                                    Examples:
+                                      1.5 will be serialized as "1500m"
+                                      1.5Gi will be serialized as "1536Mi"
+
+                                    Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                    Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                    This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                  nullable: true
+                                  type: string
+                                runtimeLimits:
+                                  type: object
+                              type: object
+                            storage:
+                              properties:
+                                data:
+                                  default:
+                                    capacity: null
+                                  properties:
+                                    capacity:
+                                      description: |-
+                                        Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                        The serialization format is:
+
+                                        <quantity>        ::= <signedNumber><suffix>
+                                          (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                        <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                          (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                        <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                          (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                        <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                        No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                        When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                        Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                          a. No precision is lost
+                                          b. No fractional digits will be emitted
+                                          c. The exponent (or suffix) is as large as possible.
+                                        The sign will be omitted unless the number is negative.
+
+                                        Examples:
+                                          1.5 will be serialized as "1500m"
+                                          1.5Gi will be serialized as "1536Mi"
+
+                                        Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                        Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                        This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                      nullable: true
+                                      type: string
+                                    selectors:
+                                      description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                                      nullable: true
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    storageClass:
+                                      nullable: true
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
                       type: object
                     configOverrides:
                       additionalProperties:
@@ -167,6 +364,203 @@ spec:
                               queryMaxMemoryPerNode:
                                 nullable: true
                                 type: string
+                              resources:
+                                nullable: true
+                                properties:
+                                  cpu:
+                                    default:
+                                      min: null
+                                      max: null
+                                    properties:
+                                      max:
+                                        description: |-
+                                          Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                          The serialization format is:
+
+                                          <quantity>        ::= <signedNumber><suffix>
+                                            (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                          <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                            (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                          <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                            (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                          <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                          No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                          When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                          Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                            a. No precision is lost
+                                            b. No fractional digits will be emitted
+                                            c. The exponent (or suffix) is as large as possible.
+                                          The sign will be omitted unless the number is negative.
+
+                                          Examples:
+                                            1.5 will be serialized as "1500m"
+                                            1.5Gi will be serialized as "1536Mi"
+
+                                          Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                          Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                          This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                        nullable: true
+                                        type: string
+                                      min:
+                                        description: |-
+                                          Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                          The serialization format is:
+
+                                          <quantity>        ::= <signedNumber><suffix>
+                                            (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                          <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                            (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                          <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                            (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                          <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                          No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                          When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                          Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                            a. No precision is lost
+                                            b. No fractional digits will be emitted
+                                            c. The exponent (or suffix) is as large as possible.
+                                          The sign will be omitted unless the number is negative.
+
+                                          Examples:
+                                            1.5 will be serialized as "1500m"
+                                            1.5Gi will be serialized as "1536Mi"
+
+                                          Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                          Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                          This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                        nullable: true
+                                        type: string
+                                    type: object
+                                  memory:
+                                    properties:
+                                      limit:
+                                        description: |-
+                                          Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                          The serialization format is:
+
+                                          <quantity>        ::= <signedNumber><suffix>
+                                            (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                          <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                            (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                          <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                            (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                          <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                          No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                          When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                          Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                            a. No precision is lost
+                                            b. No fractional digits will be emitted
+                                            c. The exponent (or suffix) is as large as possible.
+                                          The sign will be omitted unless the number is negative.
+
+                                          Examples:
+                                            1.5 will be serialized as "1500m"
+                                            1.5Gi will be serialized as "1536Mi"
+
+                                          Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                          Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                          This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                        nullable: true
+                                        type: string
+                                      runtimeLimits:
+                                        type: object
+                                    type: object
+                                  storage:
+                                    properties:
+                                      data:
+                                        default:
+                                          capacity: null
+                                        properties:
+                                          capacity:
+                                            description: |-
+                                              Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                              The serialization format is:
+
+                                              <quantity>        ::= <signedNumber><suffix>
+                                                (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                              <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                                (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                              <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                                (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                              <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                              No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                              When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                              Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                                a. No precision is lost
+                                                b. No fractional digits will be emitted
+                                                c. The exponent (or suffix) is as large as possible.
+                                              The sign will be omitted unless the number is negative.
+
+                                              Examples:
+                                                1.5 will be serialized as "1500m"
+                                                1.5Gi will be serialized as "1536Mi"
+
+                                              Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                              Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                              This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                            nullable: true
+                                            type: string
+                                          selectors:
+                                            description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                                            nullable: true
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label key that the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                          storageClass:
+                                            nullable: true
+                                            type: string
+                                        type: object
+                                    type: object
+                                type: object
                             type: object
                           configOverrides:
                             additionalProperties:
@@ -262,6 +656,203 @@ spec:
                         queryMaxMemoryPerNode:
                           nullable: true
                           type: string
+                        resources:
+                          nullable: true
+                          properties:
+                            cpu:
+                              default:
+                                min: null
+                                max: null
+                              properties:
+                                max:
+                                  description: |-
+                                    Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                    The serialization format is:
+
+                                    <quantity>        ::= <signedNumber><suffix>
+                                      (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                    <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                      (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                    <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                      (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                    <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                    No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                    When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                    Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                      a. No precision is lost
+                                      b. No fractional digits will be emitted
+                                      c. The exponent (or suffix) is as large as possible.
+                                    The sign will be omitted unless the number is negative.
+
+                                    Examples:
+                                      1.5 will be serialized as "1500m"
+                                      1.5Gi will be serialized as "1536Mi"
+
+                                    Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                    Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                    This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                  nullable: true
+                                  type: string
+                                min:
+                                  description: |-
+                                    Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                    The serialization format is:
+
+                                    <quantity>        ::= <signedNumber><suffix>
+                                      (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                    <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                      (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                    <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                      (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                    <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                    No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                    When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                    Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                      a. No precision is lost
+                                      b. No fractional digits will be emitted
+                                      c. The exponent (or suffix) is as large as possible.
+                                    The sign will be omitted unless the number is negative.
+
+                                    Examples:
+                                      1.5 will be serialized as "1500m"
+                                      1.5Gi will be serialized as "1536Mi"
+
+                                    Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                    Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                    This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                  nullable: true
+                                  type: string
+                              type: object
+                            memory:
+                              properties:
+                                limit:
+                                  description: |-
+                                    Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                    The serialization format is:
+
+                                    <quantity>        ::= <signedNumber><suffix>
+                                      (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                    <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                      (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                    <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                      (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                    <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                    No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                    When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                    Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                      a. No precision is lost
+                                      b. No fractional digits will be emitted
+                                      c. The exponent (or suffix) is as large as possible.
+                                    The sign will be omitted unless the number is negative.
+
+                                    Examples:
+                                      1.5 will be serialized as "1500m"
+                                      1.5Gi will be serialized as "1536Mi"
+
+                                    Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                    Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                    This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                  nullable: true
+                                  type: string
+                                runtimeLimits:
+                                  type: object
+                              type: object
+                            storage:
+                              properties:
+                                data:
+                                  default:
+                                    capacity: null
+                                  properties:
+                                    capacity:
+                                      description: |-
+                                        Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                        The serialization format is:
+
+                                        <quantity>        ::= <signedNumber><suffix>
+                                          (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                        <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                          (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                        <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                          (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                        <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                        No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                        When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                        Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                          a. No precision is lost
+                                          b. No fractional digits will be emitted
+                                          c. The exponent (or suffix) is as large as possible.
+                                        The sign will be omitted unless the number is negative.
+
+                                        Examples:
+                                          1.5 will be serialized as "1500m"
+                                          1.5Gi will be serialized as "1536Mi"
+
+                                        Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                        Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                        This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                      nullable: true
+                                      type: string
+                                    selectors:
+                                      description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                                      nullable: true
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    storageClass:
+                                      nullable: true
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
                       type: object
                     configOverrides:
                       additionalProperties:
@@ -295,6 +886,203 @@ spec:
                               queryMaxMemoryPerNode:
                                 nullable: true
                                 type: string
+                              resources:
+                                nullable: true
+                                properties:
+                                  cpu:
+                                    default:
+                                      min: null
+                                      max: null
+                                    properties:
+                                      max:
+                                        description: |-
+                                          Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                          The serialization format is:
+
+                                          <quantity>        ::= <signedNumber><suffix>
+                                            (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                          <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                            (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                          <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                            (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                          <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                          No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                          When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                          Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                            a. No precision is lost
+                                            b. No fractional digits will be emitted
+                                            c. The exponent (or suffix) is as large as possible.
+                                          The sign will be omitted unless the number is negative.
+
+                                          Examples:
+                                            1.5 will be serialized as "1500m"
+                                            1.5Gi will be serialized as "1536Mi"
+
+                                          Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                          Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                          This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                        nullable: true
+                                        type: string
+                                      min:
+                                        description: |-
+                                          Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                          The serialization format is:
+
+                                          <quantity>        ::= <signedNumber><suffix>
+                                            (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                          <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                            (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                          <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                            (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                          <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                          No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                          When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                          Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                            a. No precision is lost
+                                            b. No fractional digits will be emitted
+                                            c. The exponent (or suffix) is as large as possible.
+                                          The sign will be omitted unless the number is negative.
+
+                                          Examples:
+                                            1.5 will be serialized as "1500m"
+                                            1.5Gi will be serialized as "1536Mi"
+
+                                          Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                          Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                          This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                        nullable: true
+                                        type: string
+                                    type: object
+                                  memory:
+                                    properties:
+                                      limit:
+                                        description: |-
+                                          Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                          The serialization format is:
+
+                                          <quantity>        ::= <signedNumber><suffix>
+                                            (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                          <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                            (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                          <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                            (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                          <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                          No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                          When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                          Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                            a. No precision is lost
+                                            b. No fractional digits will be emitted
+                                            c. The exponent (or suffix) is as large as possible.
+                                          The sign will be omitted unless the number is negative.
+
+                                          Examples:
+                                            1.5 will be serialized as "1500m"
+                                            1.5Gi will be serialized as "1536Mi"
+
+                                          Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                          Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                          This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                        nullable: true
+                                        type: string
+                                      runtimeLimits:
+                                        type: object
+                                    type: object
+                                  storage:
+                                    properties:
+                                      data:
+                                        default:
+                                          capacity: null
+                                        properties:
+                                          capacity:
+                                            description: |-
+                                              Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                              The serialization format is:
+
+                                              <quantity>        ::= <signedNumber><suffix>
+                                                (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                              <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                                (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                              <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                                (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                              <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                              No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                              When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                              Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                                a. No precision is lost
+                                                b. No fractional digits will be emitted
+                                                c. The exponent (or suffix) is as large as possible.
+                                              The sign will be omitted unless the number is negative.
+
+                                              Examples:
+                                                1.5 will be serialized as "1500m"
+                                                1.5Gi will be serialized as "1536Mi"
+
+                                              Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                              Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                              This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                            nullable: true
+                                            type: string
+                                          selectors:
+                                            description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                                            nullable: true
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label key that the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                          storageClass:
+                                            nullable: true
+                                            type: string
+                                        type: object
+                                    type: object
+                                type: object
                             type: object
                           configOverrides:
                             additionalProperties:

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -488,3 +488,89 @@ workers:
 ----
 
 Here too, overriding properties such as `http-server.https.port` will lead to broken installations.
+
+=== Storage for data volumes
+
+You can mount volumes where data is stored by specifying https://kubernetes.io/docs/concepts/storage/persistent-volumes[PersistentVolumeClaims] for each individual role or role group:
+
+[source,yaml]
+----
+workers:
+  config:
+    resources:
+      storage:
+        data:
+          capacity: 2Gi
+  roleGroups:
+    default:
+      config:
+        resources:
+          storage:
+            data:
+              capacity: 3Gi
+----
+
+In the above example, all Trino workers in the default group will store data (the location of the property `dataDir`) on a `3Gi` volume. Additional role groups not specifying any resources will inherit the config provided on the role level (`2Gi` volume). This works the same for memory or CPU requests.
+
+By default, in case nothing is configured in the custom resource for a certain role group, each Pod will have a `1Gi` large local volume mount for the data location.
+
+=== Memory requests
+
+You can request a certain amount of memory for each individual role group as shown below:
+
+[source,yaml]
+----
+workers:
+  roleGroups:
+    default:
+      config:
+        resources:
+          memory:
+            limit: '2Gi'
+----
+
+In this example, each Trino container in the "default" group will have a maximum of 2 gigabytes of memory. To be more precise, these memory limits apply to the containers running the Trino daemons but not to any sidecar containers that are part of the pod.
+
+Setting this property will also automatically set the maximum Java heap size for the corresponding process to 80% of the available memory. Be aware that if the memory constraint is too low, the cluster might fail to start. If pods terminate with an 'OOMKilled' status and the cluster doesn't start, try increasing the memory limit.
+
+For more details regarding Kubernetes memory requests and limits see: https://kubernetes.io/docs/tasks/configure-pod-container/assign-memory-resource/[Assign Memory Resources to Containers and Pods].
+
+=== CPU requests
+
+Similarly to memory resources, you can also configure CPU limits, as shown below:
+
+[source,yaml]
+----
+workers:
+  roleGroups:
+    default:
+      config:
+        resources:
+          cpu:
+            max: '500m'
+            min: '250m'
+----
+
+=== Defaults
+
+If nothing is specified, the operator will automatically set the following default values for resources:
+
+[source,yaml]
+----
+workers:
+  roleGroups:
+    default:
+      config:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 2Gi
+          limits:
+            cpu: "1"
+            memory: 2Gi
+          storage:
+            data:
+              capacity: 2Gi
+----
+
+For more details regarding Kubernetes CPU limits see: https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource/[Assign CPU Resources to Containers and Pods].

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -510,7 +510,7 @@ workers:
               capacity: 3Gi
 ----
 
-In the above example, all Trino workers in the default group will store data (the location of the property `dataDir`) on a `3Gi` volume. Additional role groups not specifying any resources will inherit the config provided on the role level (`2Gi` volume). This works the same for memory or CPU requests.
+In the above example, all Trino workers in the default group will store data (the location of the property `--data-dir`) on a `3Gi` volume. Additional role groups not specifying any resources will inherit the config provided on the role level (`2Gi` volume). This works the same for memory or CPU requests.
 
 By default, in case nothing is configured in the custom resource for a certain role group, each Pod will have a `1Gi` large local volume mount for the data location.
 
@@ -572,5 +572,7 @@ workers:
             data:
               capacity: 2Gi
 ----
+
+WARNING: The default values are _most likely_ not sufficient to run a proper cluster in production. Please adapt according to your requirements.
 
 For more details regarding Kubernetes CPU limits see: https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource/[Assign CPU Resources to Containers and Pods].

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -491,7 +491,7 @@ Here too, overriding properties such as `http-server.https.port` will lead to br
 
 === Storage for data volumes
 
-You can mount volumes where data is stored by specifying https://kubernetes.io/docs/concepts/storage/persistent-volumes[PersistentVolumeClaims] for each individual role or role group:
+You can mount a volume where data (config and logs of Trino) is stored by specifying https://kubernetes.io/docs/concepts/storage/persistent-volumes[PersistentVolumeClaims] for each individual role or role group:
 
 [source,yaml]
 ----
@@ -512,7 +512,7 @@ workers:
 
 In the above example, all Trino workers in the default group will store data (the location of the property `--data-dir`) on a `3Gi` volume. Additional role groups not specifying any resources will inherit the config provided on the role level (`2Gi` volume). This works the same for memory or CPU requests.
 
-By default, in case nothing is configured in the custom resource for a certain role group, each Pod will have a `1Gi` large local volume mount for the data location.
+By default, in case nothing is configured in the custom resource for a certain role group, each Pod will have a `2Gi` large local volume mount for the data location containing mainly logs.
 
 === Memory requests
 
@@ -529,7 +529,7 @@ workers:
             limit: '2Gi'
 ----
 
-In this example, each Trino container in the "default" group will have a maximum of 2 gigabytes of memory. To be more precise, these memory limits apply to the containers running the Trino daemons but not to any sidecar containers that are part of the pod.
+In this example, each Trino container in the `default` group will have a maximum of 2 gigabytes of memory. To be more precise, these memory limits apply to the container running Trino but not to any sidecar containers that are part of the pod.
 
 Setting this property will also automatically set the maximum Java heap size for the corresponding process to 80% of the available memory. Be aware that if the memory constraint is too low, the cluster might fail to start. If pods terminate with an 'OOMKilled' status and the cluster doesn't start, try increasing the memory limit.
 
@@ -563,10 +563,10 @@ workers:
       config:
         resources:
           requests:
-            cpu: 100m
+            cpu: 200m
             memory: 2Gi
           limits:
-            cpu: "1"
+            cpu: "4"
             memory: 2Gi
           storage:
             data:

--- a/examples/simple-trino-cluster-resource-limits.yaml
+++ b/examples/simple-trino-cluster-resource-limits.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: trino.stackable.tech/v1alpha1
+kind: TrinoCluster
+metadata:
+  name: simple-trino
+spec:
+  version: 387-stackable0.1.0
+  coordinators:
+    roleGroups:
+      default:
+        replicas: 1
+  workers:
+    roleGroups:
+      default:
+        replicas: 1
+        config:
+          resources:
+            storage:
+              data:
+                capacity: 3Gi
+            cpu:
+              min: 300m
+              max: "2"
+            memory:
+              limit: 3Gi

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -607,7 +607,7 @@ impl TrinoCluster {
         self.get_client_tls().is_some() || self.get_internal_tls().is_some()
     }
 
-    /// Retrieve and merge resource configs for role and rolegroup
+    /// Retrieve and merge resource configs for role and role groups
     pub fn resolve_resource_config_for_role_and_rolegroup(
         &self,
         role: &TrinoRole,

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -276,7 +276,7 @@ pub struct TrinoStorageConfig {
     pub data: PvcConfig,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, JsonSchema, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TrinoConfig {
     // config.properties

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -7,8 +7,12 @@ use crate::{authentication::Authentication, discovery::TrinoPodRef};
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, Snafu};
 use stackable_operator::{
-    commons::opa::OpaConfig,
-    k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector,
+    commons::{
+        opa::OpaConfig,
+        resources::{CpuLimits, MemoryLimits, NoRuntimeLimits, PvcConfig, Resources},
+    },
+    config::merge::Merge,
+    k8s_openapi::apimachinery::pkg::{api::resource::Quantity, apis::meta::v1::LabelSelector},
     kube::{runtime::reflector::ObjectRef, CustomResource, ResourceExt},
     product_config_utils::{ConfigError, Configuration},
     role_utils::{Role, RoleGroupRef},
@@ -99,6 +103,8 @@ pub const SECRET_KEY_S3_ACCESS_KEY: &str = "accessKey";
 pub const SECRET_KEY_S3_SECRET_KEY: &str = "secretKey";
 // TLS
 pub const TLS_DEFAULT_SECRET_CLASS: &str = "tls";
+
+pub const JVM_HEAP_FACTOR: f32 = 0.8;
 
 #[derive(Snafu, Debug)]
 pub enum Error {
@@ -263,6 +269,13 @@ impl FromStr for TrinoRole {
 #[serde(rename_all = "camelCase")]
 pub struct TrinoClusterStatus {}
 
+#[derive(Clone, Debug, Default, Deserialize, Merge, JsonSchema, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrinoStorageConfig {
+    #[serde(default)]
+    pub data: PvcConfig,
+}
+
 #[derive(Clone, Debug, Default, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TrinoConfig {
@@ -271,6 +284,30 @@ pub struct TrinoConfig {
     pub query_max_memory_per_node: Option<String>,
     // log.properties
     pub log_level: Option<String>,
+    // misc
+    pub resources: Option<Resources<TrinoStorageConfig, NoRuntimeLimits>>,
+}
+
+impl TrinoConfig {
+    fn default_resources() -> Resources<TrinoStorageConfig, NoRuntimeLimits> {
+        Resources {
+            cpu: CpuLimits {
+                min: Some(Quantity("100m".to_owned())),
+                max: Some(Quantity("1".to_owned())),
+            },
+            memory: MemoryLimits {
+                limit: Some(Quantity("2Gi".to_owned())),
+                runtime_limits: NoRuntimeLimits {},
+            },
+            storage: TrinoStorageConfig {
+                data: PvcConfig {
+                    capacity: Some(Quantity("2Gi".to_owned())),
+                    storage_class: None,
+                    selectors: None,
+                },
+            },
+        }
+    }
 }
 
 impl Configuration for TrinoConfig {
@@ -568,6 +605,43 @@ impl TrinoCluster {
     /// Returns if the HTTPS port should be enabled
     pub fn https_port_enabled(&self) -> bool {
         self.get_client_tls().is_some() || self.get_internal_tls().is_some()
+    }
+
+    /// Retrieve and merge resource configs for role and rolegroup
+    pub fn resolve_resource_config_for_role_and_rolegroup(
+        &self,
+        role: &TrinoRole,
+        rolegroup_ref: &RoleGroupRef<TrinoCluster>,
+    ) -> Option<Resources<TrinoStorageConfig, NoRuntimeLimits>> {
+        // Initialize the result with all default values as baseline
+        let conf_defaults = TrinoConfig::default_resources();
+
+        let role = match role {
+            TrinoRole::Coordinator => self.spec.coordinators.as_ref()?,
+            TrinoRole::Worker => self.spec.workers.as_ref()?,
+        };
+
+        // Retrieve role resource config
+        let mut conf_role: Resources<TrinoStorageConfig, NoRuntimeLimits> =
+            role.config.config.resources.clone().unwrap_or_default();
+
+        // Retrieve rolegroup specific resource config
+        let mut conf_rolegroup: Resources<TrinoStorageConfig, NoRuntimeLimits> = role
+            .role_groups
+            .get(&rolegroup_ref.role_group)
+            .and_then(|rg| rg.config.config.resources.clone())
+            .unwrap_or_default();
+
+        // Merge more specific configs into default config
+        // Hierarchy is:
+        // 1. RoleGroup
+        // 2. Role
+        // 3. Default
+        conf_role.merge(&conf_defaults);
+        conf_rolegroup.merge(&conf_role);
+
+        tracing::debug!("Merged resource config: {:?}", conf_rolegroup);
+        Some(conf_rolegroup)
     }
 }
 

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -292,8 +292,8 @@ impl TrinoConfig {
     fn default_resources() -> Resources<TrinoStorageConfig, NoRuntimeLimits> {
         Resources {
             cpu: CpuLimits {
-                min: Some(Quantity("100m".to_owned())),
-                max: Some(Quantity("1".to_owned())),
+                min: Some(Quantity("200m".to_owned())),
+                max: Some(Quantity("4".to_owned())),
             },
             memory: MemoryLimits {
                 limit: Some(Quantity("2Gi".to_owned())),

--- a/rust/operator-binary/src/catalog/config.rs
+++ b/rust/operator-binary/src/catalog/config.rs
@@ -106,7 +106,7 @@ impl CatalogConfig {
 }
 
 fn calculate_env_name(catalog: impl Into<String>, property: impl Into<String>) -> String {
-    let catalog = catalog.into().replace('.', "_").replace('-', "_");
-    let property = property.into().replace('.', "_").replace('-', "_");
+    let catalog = catalog.into().replace(['.', '-'], "_");
+    let property = property.into().replace(['.', '-'], "_");
     format!("CATALOG_{catalog}_{property}").to_uppercase()
 }

--- a/tests/templates/kuttl/resources/10-assert.yaml
+++ b/tests/templates/kuttl/resources/10-assert.yaml
@@ -1,0 +1,123 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: trino-coordinator-resources-default
+spec:
+  template:
+    spec:
+      containers:
+        - name: trino
+          resources:
+            requests:
+              cpu: 100m
+              memory: 2Gi
+            limits:
+              cpu: "1"
+              memory: 2Gi
+status:
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data-trino-coordinator-resources-default-0
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+status:
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 2Gi
+  phase: Bound
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: trino-worker-resources-from-role
+spec:
+  template:
+    spec:
+      containers:
+        - name: trino
+          resources:
+            requests:
+              cpu: 300m
+              memory: 3Gi
+            limits:
+              cpu: 600m
+              memory: 3Gi
+status:
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data-trino-worker-resources-from-role-0
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 3Gi
+status:
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 3Gi
+  phase: Bound
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: trino-worker-resources-from-role-group
+spec:
+  template:
+    spec:
+      containers:
+        - name: trino
+          resources:
+            requests:
+              cpu: 400m
+              memory: 4Gi
+            limits:
+              cpu: 800m
+              memory: 4Gi
+status:
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data-trino-worker-resources-from-role-group-0
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 4Gi
+status:
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 4Gi
+  phase: Bound
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 600
+commands:
+  - script: kubectl get cm -n $NAMESPACE trino-coordinator-resources-default -o yaml | grep -- '-Xmx1638m' | xargs test ! -z
+  - script: kubectl get cm -n $NAMESPACE trino-worker-resources-from-role -o yaml | grep -- '-Xmx2457m' | xargs test ! -z
+  - script: kubectl get cm -n $NAMESPACE trino-worker-resources-from-role-group -o yaml | grep -- '-Xmx3276m' | xargs test ! -z

--- a/tests/templates/kuttl/resources/10-assert.yaml
+++ b/tests/templates/kuttl/resources/10-assert.yaml
@@ -14,10 +14,10 @@ spec:
         - name: trino
           resources:
             requests:
-              cpu: 100m
+              cpu: 200m
               memory: 2Gi
             limits:
-              cpu: "1"
+              cpu: "4"
               memory: 2Gi
 status:
   readyReplicas: 1

--- a/tests/templates/kuttl/resources/10-install-trino.yaml.j2
+++ b/tests/templates/kuttl/resources/10-install-trino.yaml.j2
@@ -1,0 +1,37 @@
+---
+apiVersion: trino.stackable.tech/v1alpha1
+kind: TrinoCluster
+metadata:
+  name: trino
+spec:
+  version: {{ test_scenario['values']['trino'] }}
+  coordinators:
+    roleGroups:
+      resources-default:
+        replicas: 1
+  workers:
+    config:
+      resources:
+        storage:
+          data:
+            capacity: 3Gi
+        cpu:
+          min: 300m
+          max: 600m
+        memory:
+          limit: 3Gi
+    roleGroups:
+      resources-from-role:
+        replicas: 1
+      resources-from-role-group:
+        replicas: 1
+        config:
+          resources:
+            storage:
+              data:
+                capacity: 4Gi
+            cpu:
+              min: 400m
+              max: 800m
+            memory:
+              limit: 4Gi

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -49,3 +49,6 @@ tests:
       - use-authentication
       - use-tls
       - use-internal-tls
+  - name: resources
+    dimensions:
+      - trino


### PR DESCRIPTION
# Description

- PVC, memory and CPU requests and limits now configurable
- added new integration tests folder "resources"

closes https://github.com/stackabletech/trino-operator/issues/248

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [x] Code contains useful comments
- [x] CRD change approved (or not applicable)
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
