### PR TITLE
[Merged by Bors] - Add temporary attribute to support using ClusterIP instead of NodePort service type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Add support for connecting to HDFS ([#263]).
 - Add support for Hive 3.1.3 ([#243]).
 - PVCs for data storage, cpu and memory limits are now configurable ([#270]).
+- Add temporary attribute to support using ClusterIP instead of NodePort service type ([#272]).
 
 ### Changed
 
@@ -31,6 +32,7 @@ All notable changes to this project will be documented in this file.
 [#244]: https://github.com/stackabletech/trino-operator/pull/244
 [#263]: https://github.com/stackabletech/trino-operator/pull/263
 [#270]: https://github.com/stackabletech/trino-operator/pull/270
+[#272]: https://github.com/stackabletech/trino-operator/pull/272
 
 ## [0.4.0] - 2022-06-30
 

--- a/deploy/crd/trinocluster.crd.yaml
+++ b/deploy/crd/trinocluster.crd.yaml
@@ -377,6 +377,13 @@ spec:
                   required:
                     - configMapName
                   type: object
+                serviceType:
+                  description: Specify the type of the created kubernetes service. This attribute will be removed in a future release when listener-operator is finished. Use with caution.
+                  enum:
+                    - NodePort
+                    - ClusterIP
+                  nullable: true
+                  type: string
                 stopped:
                   description: "Emergency stop button, if `true` then all pods are stopped without affecting configuration (as setting `replicas` to `0` would)."
                   nullable: true

--- a/deploy/helm/trino-operator/crds/crds.yaml
+++ b/deploy/helm/trino-operator/crds/crds.yaml
@@ -626,6 +626,13 @@ spec:
                   required:
                     - configMapName
                   type: object
+                serviceType:
+                  description: Specify the type of the created kubernetes service. This attribute will be removed in a future release when listener-operator is finished. Use with caution.
+                  enum:
+                    - NodePort
+                    - ClusterIP
+                  nullable: true
+                  type: string
                 stopped:
                   description: Emergency stop button, if `true` then all pods are stopped without affecting configuration (as setting `replicas` to `0` would).
                   nullable: true

--- a/deploy/manifests/crds.yaml
+++ b/deploy/manifests/crds.yaml
@@ -627,6 +627,13 @@ spec:
                   required:
                     - configMapName
                   type: object
+                serviceType:
+                  description: Specify the type of the created kubernetes service. This attribute will be removed in a future release when listener-operator is finished. Use with caution.
+                  enum:
+                    - NodePort
+                    - ClusterIP
+                  nullable: true
+                  type: string
                 stopped:
                   description: Emergency stop button, if `true` then all pods are stopped without affecting configuration (as setting `replicas` to `0` would).
                   nullable: true

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -159,6 +159,25 @@ pub struct TrinoClusterSpec {
     /// Settings for the Worker Role/Process.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workers: Option<Role<TrinoConfig>>,
+    /// Specify the type of the created kubernetes service.
+    /// This attribute will be removed in a future release when listener-operator is finished.
+    /// Use with caution.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_type: Option<ServiceType>,
+}
+
+// TODO: Temporary solution until listener-operator is finished
+#[derive(Clone, Debug, Display, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum ServiceType {
+    NodePort,
+    ClusterIP,
+}
+
+impl Default for ServiceType {
+    fn default() -> Self {
+        Self::NodePort
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -333,7 +333,14 @@ pub fn build_coordinator_role_service(trino: &TrinoCluster) -> Result<Service> {
         spec: Some(ServiceSpec {
             ports: Some(service_ports(trino)),
             selector: Some(role_selector_labels(trino, APP_NAME, &role_name)),
-            type_: Some("NodePort".to_string()),
+            type_: Some(
+                trino
+                    .spec
+                    .service_type
+                    .clone()
+                    .unwrap_or_default()
+                    .to_string(),
+            ),
             ..ServiceSpec::default()
         }),
         status: None,


### PR DESCRIPTION
# Description

Fixes https://github.com/stackabletech/trino-operator/issues/269

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [x] Code contains useful comments
- [x] CRD change approved (or not applicable)
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
