### PR TITLE
[Merged by Bors] - TrinoClusters must specify a catalogLabelSelector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- BREAKING: TrinoClusters now must specify a `catalogLabelSelector`. Previously all TrinoCatalogs within the same namespace where used when `catalogLabelSelector` was not specified, which is unwanted behaviour ([#277]).
+- BREAKING: TrinoClusters must specify a `catalogLabelSelector`. Previously all TrinoCatalogs within the same namespace where used when `catalogLabelSelector` was not specified, which is unwanted behaviour ([#277]).
 
 [#277]: https://github.com/stackabletech/trino-operator/pull/277
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- BREAKING: TrinoClusters now must specify a `catalogLabelSelector`. Previously all TrinoCatalogs within the same namespace where used when `catalogLabelSelector` was not specified ([#277]).
+
+[#277]: https://github.com/stackabletech/trino-operator/pull/277
+
 ## [0.5.0] - 2022-09-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- BREAKING: TrinoClusters now must specify a `catalogLabelSelector`. Previously all TrinoCatalogs within the same namespace where used when `catalogLabelSelector` was not specified ([#277]).
+- BREAKING: TrinoClusters now must specify a `catalogLabelSelector`. Previously all TrinoCatalogs within the same namespace where used when `catalogLabelSelector` was not specified, which is unwanted behaviour ([#277]).
 
 [#277]: https://github.com/stackabletech/trino-operator/pull/277
 

--- a/deploy/crd/trinocluster.crd.yaml
+++ b/deploy/crd/trinocluster.crd.yaml
@@ -51,7 +51,6 @@ spec:
                   type: object
                 catalogLabelSelector:
                   description: "[LabelSelector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) selecting the Catalogs to include in the Trino instance"
-                  nullable: true
                   properties:
                     matchExpressions:
                       description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -646,6 +645,8 @@ spec:
                   required:
                     - roleGroups
                   type: object
+              required:
+                - catalogLabelSelector
               type: object
             status:
               nullable: true

--- a/deploy/helm/trino-operator/crds/crds.yaml
+++ b/deploy/helm/trino-operator/crds/crds.yaml
@@ -52,7 +52,6 @@ spec:
                   type: object
                 catalogLabelSelector:
                   description: '[LabelSelector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) selecting the Catalogs to include in the Trino instance'
-                  nullable: true
                   properties:
                     matchExpressions:
                       description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -1143,6 +1142,8 @@ spec:
                   required:
                     - roleGroups
                   type: object
+              required:
+                - catalogLabelSelector
               type: object
             status:
               nullable: true

--- a/deploy/manifests/crds.yaml
+++ b/deploy/manifests/crds.yaml
@@ -53,7 +53,6 @@ spec:
                   type: object
                 catalogLabelSelector:
                   description: '[LabelSelector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) selecting the Catalogs to include in the Trino instance'
-                  nullable: true
                   properties:
                     matchExpressions:
                       description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -1144,6 +1143,8 @@ spec:
                   required:
                     - roleGroups
                   type: object
+              required:
+                - catalogLabelSelector
               type: object
             status:
               nullable: true

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -115,7 +115,6 @@ metadata:
   name: simple-trino
 spec:
   version: 387-stackable0.1.0
-  hiveConfigMapName: simple-hive-derby
   catalogLabelSelector:
     matchLabels:
       trino: simple-trino

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -117,7 +117,8 @@ spec:
   version: 387-stackable0.1.0
   hiveConfigMapName: simple-hive-derby
   catalogLabelSelector:
-    trino: simple-trino
+    matchLabels:
+      trino: simple-trino
   coordinators:
     roleGroups:
       default:

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -154,8 +154,7 @@ pub struct TrinoClusterSpec {
     pub coordinators: Option<Role<TrinoConfig>>,
     /// [LabelSelector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) selecting the Catalogs
     /// to include in the Trino instance
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub catalog_label_selector: Option<LabelSelector>,
+    pub catalog_label_selector: LabelSelector,
     /// Settings for the Worker Role/Process.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workers: Option<Role<TrinoConfig>>,

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -676,6 +676,7 @@ mod tests {
           name: simple-trino
         spec:
           version: abc
+          catalogLabelSelector: {}
         "#;
         let trino: TrinoCluster = serde_yaml::from_str(input).expect("illegal test input");
         assert_eq!(
@@ -694,6 +695,7 @@ mod tests {
           name: simple-trino
         spec:
           version: abc
+          catalogLabelSelector: {}
           config:
             tls:
               secretClass: simple-trino-client-tls
@@ -715,6 +717,7 @@ mod tests {
           name: simple-trino
         spec:
           version: abc
+          catalogLabelSelector: {}
           config:
             tls: null
         "#;
@@ -732,6 +735,7 @@ mod tests {
           name: simple-trino
         spec:
           version: abc
+          catalogLabelSelector: {}
           config:
             internalTls:
               secretClass: simple-trino-internal-tls
@@ -756,6 +760,7 @@ mod tests {
           name: simple-trino
         spec:
           version: abc
+          catalogLabelSelector: {}
         "#;
         let trino: TrinoCluster = serde_yaml::from_str(input).expect("illegal test input");
         assert_eq!(
@@ -774,6 +779,7 @@ mod tests {
           name: simple-trino
         spec:
           version: abc
+          catalogLabelSelector: {}
           config:
             internalTls:
               secretClass: simple-trino-internal-tls
@@ -795,6 +801,7 @@ mod tests {
           name: simple-trino
         spec:
           version: abc
+          catalogLabelSelector: {}
           config:
             tls:
               secretClass: simple-trino-client-tls

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -183,9 +183,7 @@ pub async fn reconcile_trino(trino: Arc<TrinoCluster>, ctx: Arc<Ctx>) -> Result<
     let catalog_definitions = client
         .list_with_label_selector::<TrinoCatalog>(
             trino.metadata.namespace.as_deref(),
-            &trino
-                .spec
-                .catalog_label_selector,
+            &trino.spec.catalog_label_selector,
         )
         .await
         .context(GetCatalogsSnafu)?;

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -55,7 +55,6 @@ use stackable_trino_crd::{
     STACKABLE_SERVER_TLS_DIR, STACKABLE_TLS_STORE_PASSWORD, USER_PASSWORD_DATA_DIR_NAME,
 };
 use std::{
-    borrow::Cow,
     collections::{BTreeMap, HashMap},
     fmt::Write,
     str::FromStr,
@@ -186,9 +185,7 @@ pub async fn reconcile_trino(trino: Arc<TrinoCluster>, ctx: Arc<Ctx>) -> Result<
             trino.metadata.namespace.as_deref(),
             &trino
                 .spec
-                .catalog_label_selector
-                .as_ref()
-                .map_or_else(Cow::default, Cow::Borrowed),
+                .catalog_label_selector,
         )
         .await
         .context(GetCatalogsSnafu)?;

--- a/tests/templates/kuttl/resources/10-install-trino.yaml.j2
+++ b/tests/templates/kuttl/resources/10-install-trino.yaml.j2
@@ -5,6 +5,7 @@ metadata:
   name: trino
 spec:
   version: {{ test_scenario['values']['trino'] }}
+  catalogLabelSelector: {}
   coordinators:
     roleGroups:
       resources-default:

--- a/tests/templates/kuttl/smoke/10-install-trino.yaml.j2
+++ b/tests/templates/kuttl/smoke/10-install-trino.yaml.j2
@@ -6,7 +6,8 @@ metadata:
 spec:
   version: {{ test_scenario['values']['trino'] }}
   catalogLabelSelector:
-    trino: simple-trino
+    matchLabels:
+      trino: trino
   opa:
     configMapName: opa
     package: trino

--- a/tests/templates/kuttl/tls/10-install-trino.yaml.j2
+++ b/tests/templates/kuttl/tls/10-install-trino.yaml.j2
@@ -46,6 +46,7 @@ metadata:
   name: trino
 spec:
   version: {{ test_scenario['values']['trino'] }}
+  catalogLabelSelector: {}
 {% if test_scenario['values']['use-tls'] == 'true' or test_scenario['values']['use-internal-tls'] == 'true' %}
   config:
 {% endif %}


### PR DESCRIPTION
# Description

During bumping the demos to the 22.09  i noticed that the following spec from the Trino tests and docs is invalid
```
apiVersion: trino.stackable.tech/v1alpha1
kind: TrinoCluster
metadata:
  name: simple-trino
spec:
  version: 387-stackable0.1.0
  catalogLabelSelector:
    trino: simple-trino
```
instead it should be 
```
# ...
  catalogLabelSelector:
    matchLabels:
      trino: simple-trino
```
Nobody noticed this, as the field `catalogLabelSelector` is optional. If it is not provided, the (nonexistent) Labelselector will match every TrinoCatalog withing the same Namespace and the test passed anyway.
This behavior sounds unsafe/unwanted so i suggest to make it explicit by requiring a Labelselector.

Although this change is technically breaking, the `TrinoCatalog` feature change has been release for a single day now, so impact should be pretty minimal. It would be greatif we could include this Change in 22.09, so that we reduce the number of breaking changes between Platform releases

## Review Checklist

- [x] Code contains useful comments
- [x] CRD change approved (or not applicable)
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)


Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
