### PR TITLE
[Merged by Bors] - Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- BREAKING: TrinoClusters must specify a `catalogLabelSelector`. Previously all TrinoCatalogs within the same namespace where used when `catalogLabelSelector` was not specified, which is unwanted behaviour ([#277]).
+- BREAKING: TrinoClusters must specify a `catalogLabelSelector`. Previously all TrinoCatalogs within the same namespace where used when `catalogLabelSelector` was not specified, which is unwanted behavior ([#277]).
 
 [#277]: https://github.com/stackabletech/trino-operator/pull/277
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.0] - 2022-09-08
+
 ### Changed
 
 - BREAKING: TrinoClusters must specify a `catalogLabelSelector`. Previously all TrinoCatalogs within the same namespace where used when `catalogLabelSelector` was not specified, which is unwanted behavior ([#277]).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1782,7 +1782,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-trino-crd"
-version = "0.6.0-nightly"
+version = "0.6.0"
 dependencies = [
  "indoc",
  "rstest",
@@ -1798,7 +1798,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-trino-operator"
-version = "0.6.0-nightly"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/deploy/helm/trino-operator/Chart.yaml
+++ b/deploy/helm/trino-operator/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v2
 name: trino-operator
-version: "0.6.0-nightly"
-appVersion: "0.6.0-nightly"
+version: "0.6.0"
+appVersion: "0.6.0"
 description: The Stackable Operator for Trino
 home: https://github.com/stackabletech/trino-operator
 maintainers:

--- a/deploy/manifests/configmap.yaml
+++ b/deploy/manifests/configmap.yaml
@@ -236,4 +236,4 @@ metadata:
   labels:
     app.kubernetes.io/name: trino-operator
     app.kubernetes.io/instance: trino-operator
-    app.kubernetes.io/version: "0.6.0-nightly"
+    app.kubernetes.io/version: "0.6.0"

--- a/deploy/manifests/deployment.yaml
+++ b/deploy/manifests/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: trino-operator
     app.kubernetes.io/instance: trino-operator
-    app.kubernetes.io/version: "0.6.0-nightly"
+    app.kubernetes.io/version: "0.6.0"
 spec:
   replicas: 1
   strategy:
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: trino-operator
           securityContext: {}
-          image: "docker.stackable.tech/stackable/trino-operator:0.6.0-nightly"
+          image: "docker.stackable.tech/stackable/trino-operator:0.6.0"
           imagePullPolicy: IfNotPresent
           resources: {}
           volumeMounts:

--- a/deploy/manifests/serviceaccount.yaml
+++ b/deploy/manifests/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: trino-operator
     app.kubernetes.io/instance: trino-operator
-    app.kubernetes.io/version: "0.6.0-nightly"
+    app.kubernetes.io/version: "0.6.0"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 # This cluster role binding allows anyone in the "manager" group to read secrets in any namespace.
@@ -16,7 +16,7 @@ metadata:
   labels:
     app.kubernetes.io/name: trino-operator
     app.kubernetes.io/instance: trino-operator
-    app.kubernetes.io/version: "0.6.0-nightly"
+    app.kubernetes.io/version: "0.6.0"
 subjects:
   - kind: ServiceAccount
     name: trino-operator-serviceaccount

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,7 +1,7 @@
 name: trino
-version: "nightly"
+version: "0.6"
 title: Stackable Operator for Trino
 nav:
   - modules/getting_started/nav.adoc
   - modules/ROOT/nav.adoc
-prerelease: true
+prerelease: false

--- a/docs/templating_vars.yaml
+++ b/docs/templating_vars.yaml
@@ -3,6 +3,6 @@ helm:
   repo_name: stackable-dev
   repo_url: https://repo.stackable.tech/repository/helm-dev/
 versions:
-  commons: 0.4.0-nightly
-  secret: 0.6.0-nightly
-  trino: 0.6.0-nightly
+  commons: 0.3.0
+  secret: 0.5.0
+  trino: 0.6.0

--- a/rust/crd/Cargo.toml
+++ b/rust/crd/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "OSL-3.0"
 name = "stackable-trino-crd"
 repository = "https://github.com/stackabletech/trino-operator"
-version = "0.6.0-nightly"
+version = "0.6.0"
 
 [dependencies]
 stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.22.0" }

--- a/rust/operator-binary/Cargo.toml
+++ b/rust/operator-binary/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "OSL-3.0"
 name = "stackable-trino-operator"
 repository = "https://github.com/stackabletech/trino-operator"
-version = "0.6.0-nightly"
+version = "0.6.0"
 
 [dependencies]
 stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.22.0" }


### PR DESCRIPTION
Proposing a release that's part of 22.09 to combine the TrinoCatalog feature (https://github.com/stackabletech/trino-operator/pull/263) with a fix that's a breaking change (https://github.com/stackabletech/trino-operator/pull/277).

By including trino-operator 0.6.0 in 22.09 we don't have a breaking change between platform releases.