### PR TITLE
[Merged by Bors] - added catalogLabelSelector

### DIFF
--- a/docs/modules/getting_started/examples/code/trino.yaml
+++ b/docs/modules/getting_started/examples/code/trino.yaml
@@ -5,6 +5,9 @@ metadata:
   name: simple-trino
 spec:
   version: 387-stackable0.1.0
+  catalogLabelSelector:
+    matchLabels:
+      trino: simple-trino
   coordinators:
     roleGroups:
       default:


### PR DESCRIPTION
# Description

Added mandatory `catalogLabelSelector` field to trino cluster definition in getting-started yaml (this change has already been made to the commit that has been tagged with `docs/0.6`).

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
