### PR TITLE
[Merged by Bors] - Fix not adding configOverwrites specified in a TrinoCatalog to the catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ All notable changes to this project will be documented in this file.
 
 - Add support for [Iceberg connector](https://trino.io/docs/current/connector/iceberg.html) ([#286]).
 
+### Fixed
+
+- Fix not adding `configOverwrites` specified in a `TrinoCatalog` to the catalog ([#289]).
+
 [#286]: https://github.com/stackabletech/trino-operator/pull/286
+[#289]: https://github.com/stackabletech/trino-operator/pull/289
 
 ## [0.6.0] - 2022-09-08
 

--- a/rust/operator-binary/src/catalog/config.rs
+++ b/rust/operator-binary/src/catalog/config.rs
@@ -108,7 +108,9 @@ impl CatalogConfig {
             }
         }?;
 
-        catalog_config.properties.extend(catalog.spec.config_overrides);
+        catalog_config
+            .properties
+            .extend(catalog.spec.config_overrides);
 
         Ok(catalog_config)
     }

--- a/rust/operator-binary/src/catalog/config.rs
+++ b/rust/operator-binary/src/catalog/config.rs
@@ -95,7 +95,7 @@ impl CatalogConfig {
         let catalog_name = catalog.name();
         let catalog_namespace = catalog.namespace();
 
-        match catalog.spec.connector {
+        let mut catalog_config = match catalog.spec.connector {
             TrinoCatalogConnector::Hive(connector) => {
                 connector
                     .to_catalog_config(&catalog_name, catalog_namespace, client)
@@ -106,7 +106,11 @@ impl CatalogConfig {
                     .to_catalog_config(&catalog_name, catalog_namespace, client)
                     .await
             }
-        }
+        }?;
+
+        catalog_config.properties.extend(catalog.spec.config_overrides);
+
+        Ok(catalog_config)
     }
 }
 


### PR DESCRIPTION
## Review Checklist

- [ ] Code contains useful comments
- [ ] CRD change approved (or not applicable)
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
