### PR TITLE
[Merged by Bors] - test: Use hdfs connection within hive metastore

### DIFF
--- a/tests/templates/kuttl/smoke/07-install-hive.yaml.j2
+++ b/tests/templates/kuttl/smoke/07-install-hive.yaml.j2
@@ -37,3 +37,5 @@ spec:
             dbType: postgres
   s3:
     reference: minio
+  hdfs:
+    configMap: hdfs

--- a/tests/templates/kuttl/smoke/check-s3.py
+++ b/tests/templates/kuttl/smoke/check-s3.py
@@ -88,12 +88,7 @@ FROM hive.minio.taxi_data
 
     print("[INFO] Testing HDFS")
 
-    # We have to put in the Namenode address *temporary* until hive metastore supports adding a HDFS connection based on the discovery configmap
-    # You can see that based on the error stacktrace:
-    # Caused by: org.apache.hadoop.hive.metastore.api.MetaException: java.lang.IllegalArgumentException: java.net.UnknownHostException: hdfs
-    # When hive supports the HDFS connection we should switch to the following command
-    # assert run_query(connection, "CREATE SCHEMA IF NOT EXISTS hive.hdfs WITH (location = 'hdfs://hdfs/trino/')")[0][0] is True
-    assert run_query(connection, "CREATE SCHEMA IF NOT EXISTS hive.hdfs WITH (location = 'hdfs://hdfs-namenode-default-0/trino/')")[0][0] is True
+    assert run_query(connection, "CREATE SCHEMA IF NOT EXISTS hive.hdfs WITH (location = 'hdfs://hdfs/trino/')")[0][0] is True
     rows_written = run_query(connection, "CREATE TABLE IF NOT EXISTS hive.hdfs.taxi_data_copy AS SELECT * FROM hive.minio.taxi_data")[0][0]
     assert rows_written == 5000 or rows_written == 0
     assert run_query(connection, "SELECT COUNT(*) FROM hive.hdfs.taxi_data_copy")[0][0] == 5000


### PR DESCRIPTION
Closes https://github.com/stackabletech/hive-operator/issues/263

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [x] Code contains useful comments
- [x] CRD change approved (or not applicable)
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
