### PR TITLE
[Merged by Bors] - Hive catalog now properly handles multiple hive metastores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,15 @@ All notable changes to this project will be documented in this file.
 - `operator-rs` `0.25.0` -> `0.27.1` ([#344]).
 - LDAP integration tests create all resources in their namespace and not some in the default namespace ([#344]).
 
+### Fixed
+
+- Hive catalog now properly handles hive clusters with replicas > 1([#348]).
+
 [#337]: https://github.com/stackabletech/trino-operator/pull/337
 [#340]: https://github.com/stackabletech/trino-operator/pull/340
 [#344]: https://github.com/stackabletech/trino-operator/pull/344
 [#347]: https://github.com/stackabletech/trino-operator/pull/347
+[#348]: https://github.com/stackabletech/trino-operator/pull/348
 
 ## [0.8.0] - 2022-11-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Hive catalog now properly handles hive clusters with replicas > 1([#348]).
+- Hive catalog now properly handles hive clusters with replicas > 1 ([#348]).
 
 [#337]: https://github.com/stackabletech/trino-operator/pull/337
 [#340]: https://github.com/stackabletech/trino-operator/pull/340

--- a/examples/simple-trino-cluster-hive-ha-s3.yaml
+++ b/examples/simple-trino-cluster-hive-ha-s3.yaml
@@ -1,0 +1,84 @@
+# stackablectl operator install commons secret hive zookeeper
+# helm install minio minio --repo https://charts.bitnami.com/bitnami --set auth.rootUser=minio-access-key --set auth.rootPassword=minio-secret-key
+---
+apiVersion: trino.stackable.tech/v1alpha1
+kind: TrinoCluster
+metadata:
+  name: simple-trino
+spec:
+  version: 396-stackable0.2.0
+  catalogLabelSelector:
+    matchLabels:
+      trino: simple-trino
+  coordinators:
+    roleGroups:
+      default:
+        replicas: 1
+  workers:
+    roleGroups:
+      default:
+        replicas: 1
+---
+apiVersion: trino.stackable.tech/v1alpha1
+kind: TrinoCatalog
+metadata:
+  name: hive
+  labels:
+    trino: simple-trino
+spec:
+  connector:
+    hive:
+      metastore:
+        configMap: simple-hive-derby
+      s3:
+        reference: minio
+---
+apiVersion: hive.stackable.tech/v1alpha1
+kind: HiveCluster
+metadata:
+  name: simple-hive-derby
+spec:
+  version: 3.1.3-stackable0.2.0
+  metastore:
+    roleGroups:
+      default:
+        replicas: 2
+        config:
+          database:
+            connString: jdbc:derby:;databaseName=/tmp/metastore_db;create=true
+            user: APP
+            password: mine
+            dbType: derby
+  s3:
+    reference: minio
+---
+apiVersion: s3.stackable.tech/v1alpha1
+kind: S3Connection
+metadata:
+  name: minio
+spec:
+  host: minio
+  port: 9000
+  accessStyle: Path
+  credentials:
+    secretClass: simple-s3-credentials-secret-class
+---
+apiVersion: secrets.stackable.tech/v1alpha1
+kind: SecretClass
+metadata:
+  name: simple-s3-credentials-secret-class
+spec:
+  backend:
+    k8sSearch:
+      searchNamespace:
+        pod: {}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: simple-s3-credentials-secret
+  labels:
+    secrets.stackable.tech/class: simple-s3-credentials-secret-class
+stringData:
+  accessKey: minio-access-key
+  secretKey: minio-secret-key

--- a/examples/simple-trino-cluster-hive-ha-s3.yaml
+++ b/examples/simple-trino-cluster-hive-ha-s3.yaml
@@ -1,5 +1,7 @@
-# stackablectl operator install commons secret hive zookeeper
+# stackablectl operator install commons secret hive trino
 # helm install minio minio --repo https://charts.bitnami.com/bitnami --set auth.rootUser=minio-access-key --set auth.rootPassword=minio-secret-key
+# helm upgrade hive --install --version=10 --set postgresqlUsername=hive --set postgresqlPassword=hive --set postgresqlDatabase=hive --repo https://charts.bitnami.com/bitnami postgresql
+# PostgreSQL is required for Hive HA to work! Does not work with Derby.
 ---
 apiVersion: trino.stackable.tech/v1alpha1
 kind: TrinoCluster
@@ -45,10 +47,10 @@ spec:
         replicas: 2
         config:
           database:
-            connString: jdbc:derby:;databaseName=/tmp/metastore_db;create=true
-            user: APP
-            password: mine
-            dbType: derby
+            connString: jdbc:postgresql://hive-postgresql:5432/hive
+            user: hive
+            password: hive
+            dbType: postgres
   s3:
     reference: minio
 ---

--- a/rust/operator-binary/src/catalog/commons.rs
+++ b/rust/operator-binary/src/catalog/commons.rs
@@ -61,9 +61,8 @@ impl ExtendCatalogConfig for MetastoreConnection {
                 data_key: data_key.to_string(),
             })?;
 
-        // This is tightly coupled now with the hive discovery config map data layout now
-        let transformed_hive_connection =
-            hive_connection.split('\n').collect::<Vec<&str>>().join(",");
+        // This is tightly coupled with the hive discovery config map data layout now
+        let transformed_hive_connection = hive_connection.replace('\n', ",");
 
         catalog_config.add_property("hive.metastore.uri", transformed_hive_connection);
 

--- a/rust/operator-binary/src/catalog/commons.rs
+++ b/rust/operator-binary/src/catalog/commons.rs
@@ -63,7 +63,7 @@ impl ExtendCatalogConfig for MetastoreConnection {
 
         // This is tightly coupled now with the hive discovery config map data layout now
         let transformed_hive_connection =
-            hive_connection.split("\n").collect::<Vec<&str>>().join(",");
+            hive_connection.split('\n').collect::<Vec<&str>>().join(",");
 
         catalog_config.add_property("hive.metastore.uri", transformed_hive_connection);
 

--- a/rust/operator-binary/src/catalog/commons.rs
+++ b/rust/operator-binary/src/catalog/commons.rs
@@ -7,6 +7,7 @@ use stackable_operator::{
     client::Client,
     commons::s3::{S3AccessStyle, S3ConnectionDef},
     commons::tls::{CaCert, TlsServerVerification, TlsVerification},
+    k8s_openapi::api::core::v1::ConfigMap,
 };
 use stackable_trino_crd::catalog::commons::{HdfsConnection, MetastoreConnection};
 use stackable_trino_crd::{
@@ -16,7 +17,8 @@ use stackable_trino_crd::{
 use super::{
     config::CatalogConfig,
     from_trino_catalog_error::{
-        ObjectHasNoNamespaceSnafu, ResolveS3ConnectionDefSnafu,
+        FailedToGetDiscoveryConfigMapDataKeySnafu, FailedToGetDiscoveryConfigMapDataSnafu,
+        FailedToGetDiscoveryConfigMapSnafu, ObjectHasNoNamespaceSnafu, ResolveS3ConnectionDefSnafu,
         S3TlsNoVerificationNotSupportedSnafu,
     },
     ExtendCatalogConfig, FromTrinoCatalogError,
@@ -27,15 +29,43 @@ impl ExtendCatalogConfig for MetastoreConnection {
     async fn extend_catalog_config(
         &self,
         catalog_config: &mut CatalogConfig,
-        _catalog_name: &str,
-        _catalog_namespace: Option<String>,
-        _client: &Client,
+        catalog_name: &str,
+        catalog_namespace: Option<String>,
+        client: &Client,
     ) -> Result<(), FromTrinoCatalogError> {
-        catalog_config.add_configmap_property(
-            "hive.metastore.uri",
-            self.config_map.clone(),
-            "HIVE",
-        );
+        let hive_cm: ConfigMap = client
+            .get(
+                &self.config_map,
+                catalog_namespace
+                    .as_deref()
+                    .context(ObjectHasNoNamespaceSnafu)?,
+            )
+            .await
+            .with_context(|_| FailedToGetDiscoveryConfigMapSnafu {
+                catalog: catalog_name.to_string(),
+                cm_name: self.config_map.to_string(),
+            })?;
+
+        let data_key = "HIVE";
+        let hive_connection = hive_cm
+            .data
+            .as_ref()
+            .with_context(|| FailedToGetDiscoveryConfigMapDataSnafu {
+                catalog: catalog_name.to_string(),
+                cm_name: self.config_map.to_string(),
+            })?
+            .get(data_key)
+            .with_context(|| FailedToGetDiscoveryConfigMapDataKeySnafu {
+                catalog: catalog_name.to_string(),
+                cm_name: self.config_map.to_string(),
+                data_key: data_key.to_string(),
+            })?;
+
+        // This is tightly coupled now with the hive discovery config map data layout now
+        let transformed_hive_connection =
+            hive_connection.split("\n").collect::<Vec<&str>>().join(",");
+
+        catalog_config.add_property("hive.metastore.uri", transformed_hive_connection);
 
         Ok(())
     }

--- a/rust/operator-binary/src/catalog/mod.rs
+++ b/rust/operator-binary/src/catalog/mod.rs
@@ -25,6 +25,24 @@ pub enum FromTrinoCatalogError {
     S3TlsNoVerificationNotSupported,
     #[snafu(display("trino catalog has no name set"))]
     InvalidCatalogSpec,
+    #[snafu(display("failed to resolve [{catalog}] discovery config map [{cm_name}]"))]
+    FailedToGetDiscoveryConfigMap {
+        source: stackable_operator::error::Error,
+        catalog: String,
+        cm_name: String,
+    },
+    #[snafu(display(
+        "failed to retrieve [{catalog}] discovery config map [{cm_name}] data field"
+    ))]
+    FailedToGetDiscoveryConfigMapData { catalog: String, cm_name: String },
+    #[snafu(display(
+        "failed to retrieve [{catalog}] discovery config map [{cm_name}] data key [{data_key}]"
+    ))]
+    FailedToGetDiscoveryConfigMapDataKey {
+        catalog: String,
+        cm_name: String,
+        data_key: String,
+    },
 }
 
 #[async_trait]

--- a/tests/templates/kuttl/smoke/07-assert.yaml
+++ b/tests/templates/kuttl/smoke/07-assert.yaml
@@ -8,5 +8,5 @@ kind: StatefulSet
 metadata:
   name: hive-metastore-default
 status:
-  readyReplicas: 1
-  replicas: 1
+  readyReplicas: 2
+  replicas: 2

--- a/tests/templates/kuttl/smoke/07-install-hive.yaml.j2
+++ b/tests/templates/kuttl/smoke/07-install-hive.yaml.j2
@@ -28,7 +28,7 @@ spec:
   metastore:
     roleGroups:
       default:
-        replicas: 1
+        replicas: 2
         config:
           database:
             connString: jdbc:postgresql://hive-postgresql:5432/hive


### PR DESCRIPTION
# Description

Hive Catalog now correctly configured if multiple hive metastores are available.
No metastore shuffling is used.

fixes https://github.com/stackabletech/trino-operator/issues/343

test: https://ci.stackable.tech/view/02%20Operator%20Tests%20(custom)/job/trino-operator-it-custom/32/

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Code contains useful comments
- [ ] CRD change approved (or not applicable)
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
