### PR TITLE
[Merged by Bors] - fix/ldap-secret-key-name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file.
 - Don't run init container as root and avoid chmod and chowning ([#353]).
 - [BREAKING]: Use Product image selection instead of version. `spec.version` has been replaced by `spec.image` ([#356]).
 - [BREAKING]: Removed tools image for init container and replaced with Trino product image. This means the latest stackable version has to be used in the product image selection ([#357])
-- [BREAKING]: Use `user` and `password` Secret keys for LDAP bind credentials Secrets, instead of env var names ([#362]) 
+- [BREAKING]: Use `user` and `password` Secret keys for LDAP bind credentials Secrets, instead of env var names ([#362])
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ All notable changes to this project will be documented in this file.
 - `operator-rs` `0.25.0` -> `0.30.1` ([#344], [#360]).
 - LDAP integration tests create all resources in their namespace and not some in the default namespace ([#344]).
 - Don't run init container as root and avoid chmod and chowning ([#353]).
-- [BREAKING] Use Product image selection instead of version. `spec.version` has been replaced by `spec.image` ([#356]).
+- [BREAKING]: Use Product image selection instead of version. `spec.version` has been replaced by `spec.image` ([#356]).
 - [BREAKING]: Removed tools image for init container and replaced with Trino product image. This means the latest stackable version has to be used in the product image selection ([#357])
+- [BREAKING]: Use `user` and `password` Secret keys for LDAP bind credentials Secrets, instead of env var names ([#362]) 
 
 ### Fixed
 
@@ -34,6 +35,7 @@ All notable changes to this project will be documented in this file.
 [#357]: https://github.com/stackabletech/trino-operator/pull/357
 [#358]: https://github.com/stackabletech/trino-operator/pull/358
 [#360]: https://github.com/stackabletech/trino-operator/pull/360
+[#362]: https://github.com/stackabletech/trino-operator/pull/362
 
 ## [0.8.0] - 2022-11-07
 

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -880,7 +880,11 @@ fn env_var_from_secret(secret_name: &Option<String>, env_var: &str) -> Option<En
     })
 }
 
-fn env_var_from_secret_with_key(secret_name: &Option<String>, secret_key: &str, env_var: &str) -> Option<EnvVar> {
+fn env_var_from_secret_with_key(
+    secret_name: &Option<String>,
+    secret_key: &str,
+    env_var: &str,
+) -> Option<EnvVar> {
     secret_name.as_ref().map(|secret| EnvVar {
         name: secret_key.to_string(),
         value_from: Some(EnvVarSource {

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -657,15 +657,17 @@ fn build_rolegroup_statefulset(
             TrinoAuthenticationConfig::MultiUser { .. } => {}
             TrinoAuthenticationConfig::Ldap(ldap) => {
                 if let Some(ldap_bind_secret) = &ldap.bind_credentials {
-                    if let Some(ldap_user) = env_var_from_secret(
+                    if let Some(ldap_user) = env_var_from_secret_with_key(
                         &Some(ldap_bind_secret.secret_class.clone()),
+                        "user",
                         LDAP_USER_ENV,
                     ) {
                         env.push(ldap_user);
                     }
 
-                    if let Some(ldap_password) = env_var_from_secret(
+                    if let Some(ldap_password) = env_var_from_secret_with_key(
                         &Some(ldap_bind_secret.secret_class.clone()),
+                        "password",
                         LDAP_PASSWORD_ENV,
                     ) {
                         env.push(ldap_password);
@@ -866,6 +868,21 @@ async fn user_authentication(
 fn env_var_from_secret(secret_name: &Option<String>, env_var: &str) -> Option<EnvVar> {
     secret_name.as_ref().map(|secret| EnvVar {
         name: env_var.to_string(),
+        value_from: Some(EnvVarSource {
+            secret_key_ref: Some(SecretKeySelector {
+                optional: Some(false),
+                name: Some(secret.to_string()),
+                key: env_var.to_string(),
+            }),
+            ..EnvVarSource::default()
+        }),
+        ..EnvVar::default()
+    })
+}
+
+fn env_var_from_secret_with_key(secret_name: &Option<String>, secret_key: &str, env_var: &str) -> Option<EnvVar> {
+    secret_name.as_ref().map(|secret| EnvVar {
+        name: secret_key.to_string(),
         value_from: Some(EnvVarSource {
             secret_key_ref: Some(SecretKeySelector {
                 optional: Some(false),

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -886,7 +886,7 @@ fn env_var_from_secret_with_key(
     env_var: &str,
 ) -> Option<EnvVar> {
     secret_name.as_ref().map(|secret| EnvVar {
-        name: secret_key.to_string(),
+        name: env_var.to_string(),
         value_from: Some(EnvVarSource {
             secret_key_ref: Some(SecretKeySelector {
                 optional: Some(false),

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -891,7 +891,7 @@ fn env_var_from_secret_with_key(
             secret_key_ref: Some(SecretKeySelector {
                 optional: Some(false),
                 name: Some(secret.to_string()),
-                key: env_var.to_string(),
+                key: secret_key.to_string(),
             }),
             ..EnvVarSource::default()
         }),

--- a/tests/templates/kuttl/ldap/12-install-trino.yaml.j2
+++ b/tests/templates/kuttl/ldap/12-install-trino.yaml.j2
@@ -6,8 +6,8 @@ metadata:
   labels:
     secrets.stackable.tech/class: trino-with-ldap-bind
 stringData:
-  LDAP_USER: cn=admin,dc=example,dc=org
-  LDAP_PASSWORD: admin
+  user: cn=admin,dc=example,dc=org
+  password: admin
 ---
 apiVersion: trino.stackable.tech/v1alpha1
 kind: TrinoCluster


### PR DESCRIPTION
# Description

This PR fixes the inconsistency of Trino with Superset and NiFi. While Superset and NiFi use "user" and "password" for the LDAP Secret keys, Trino just used it's environment variable names. 

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [x] Code contains useful comments
- [x] CRD change approved (or not applicable)
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
