### PR TITLE
Adapted tests & examples to new hdfs crd structure

### DIFF
--- a/tests/templates/kuttl/smoke/06-install-hdfs.yaml.j2
+++ b/tests/templates/kuttl/smoke/06-install-hdfs.yaml.j2
@@ -7,11 +7,12 @@ spec:
   image:
     productVersion: "{{ test_scenario['values']['hdfs'].split('-stackable')[0] }}"
     stackableVersion: "{{ test_scenario['values']['hdfs'].split('-stackable')[1] }}"
+  clusterConfig:
+    dfsReplication: 1
 {% if lookup('env', 'VECTOR_AGGREGATOR') %}
-  vectorAggregatorConfigMapName: vector-aggregator-discovery
+    vectorAggregatorConfigMapName: vector-aggregator-discovery
 {% endif %}
-  zookeeperConfigMapName: hdfs-znode
-  dfsReplication: 1
+    zookeeperConfigMapName: hdfs-znode
   nameNodes:
     config:
       logging:


### PR DESCRIPTION
# Description

part of https://github.com/stackabletech/hdfs-operator/issues/289

blocked by https://github.com/stackabletech/hdfs-operator/pull/326

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Code contains useful comments
- [ ] CRD change approved (or not applicable)
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
