### PR TITLE
[Merged by Bors] - Discard integration test logs if the upstream Vector aggregator is not available

### DIFF
--- a/tests/templates/kuttl/logging/trino-vector-aggregator-values.yaml.j2
+++ b/tests/templates/kuttl/logging/trino-vector-aggregator-values.yaml.j2
@@ -98,6 +98,8 @@ customConfig:
 {% if lookup('env', 'VECTOR_AGGREGATOR') %}
       type: vector
       address: {{ lookup('env', 'VECTOR_AGGREGATOR') }}
+      buffer:
+        when_full: drop_newest
 {% else %}
       type: blackhole
 {% endif %}


### PR DESCRIPTION
# Description

Discard integration test logs if the upstream Vector aggregator is not available

The logging tests fail if the Vector aggregator configured in the environment variable `VECTOR_AGGREGATOR` is not available, i.e. not running or under back pressure because OpenSearch is not available. If `VECTOR_AGGREGATOR` is configured then it is used as the sink for the logs. If this sink is not available then the events are not considered as processed in the transformation steps and the test assertion fails. Therefore `buffer.when_full` is set to `drop_newest` which discards the logs if the buffer is full and yet increases the processed events count which makes the tests pass.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Integration tests

https://ci.stackable.tech/view/02%20Operator%20Tests%20(custom)/job/trino-operator-it-custom/63/

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
