### PR TITLE
New version 428

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1891,8 +1891,8 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "stackable-operator"
-version = "0.52.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.52.1#18af9be0473cd6c30d7426e9ade74c90e4abce22"
+version = "0.55.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.55.0#bfbc23d3819f815413cb4135e0835acd76aecf97"
 dependencies = [
  "chrono",
  "clap",
@@ -1925,8 +1925,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator-derive"
-version = "0.52.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.52.1#18af9be0473cd6c30d7426e9ade74c90e4abce22"
+version = "0.55.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.55.0#bfbc23d3819f815413cb4135e0835acd76aecf97"
 dependencies = [
  "darling 0.20.3",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 snafu = "0.7"
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.52.1" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.55.0" }
 strum = { version = "0.25", features = ["derive"] }
 tokio = { version = "1.29", features = ["full"] }
 tracing = "0.1"

--- a/deploy/helm/trino-operator/crds/crds.yaml
+++ b/deploy/helm/trino-operator/crds/crds.yaml
@@ -632,6 +632,7 @@ spec:
                           default:
                             enableVectorAgent: null
                             containers: {}
+                          description: Logging configuration
                           properties:
                             containers:
                               additionalProperties:
@@ -639,13 +640,14 @@ spec:
                                   - required:
                                       - custom
                                   - {}
-                                description: Fragment derived from `ContainerLogConfigChoice`
+                                description: Log configuration of the container
                                 properties:
                                   console:
+                                    description: Configuration for the console appender
                                     nullable: true
                                     properties:
                                       level:
-                                        description: Log levels
+                                        description: The log level threshold. Log events with a lower log level are discarded.
                                         enum:
                                           - TRACE
                                           - DEBUG
@@ -661,14 +663,16 @@ spec:
                                     description: Custom log configuration provided in a ConfigMap
                                     properties:
                                       configMap:
+                                        description: ConfigMap containing the log configuration files
                                         nullable: true
                                         type: string
                                     type: object
                                   file:
+                                    description: Configuration for the file appender
                                     nullable: true
                                     properties:
                                       level:
-                                        description: Log levels
+                                        description: The log level threshold. Log events with a lower log level are discarded.
                                         enum:
                                           - TRACE
                                           - DEBUG
@@ -682,9 +686,10 @@ spec:
                                     type: object
                                   loggers:
                                     additionalProperties:
+                                      description: Configuration of a logger
                                       properties:
                                         level:
-                                          description: Log levels
+                                          description: The log level threshold. Log events with a lower log level are discarded.
                                           enum:
                                             - TRACE
                                             - DEBUG
@@ -697,10 +702,13 @@ spec:
                                           type: string
                                       type: object
                                     default: {}
+                                    description: Configuration per logger
                                     type: object
                                 type: object
+                              description: Log configuration per container
                               type: object
                             enableVectorAgent:
+                              description: Wether or not to deploy a container with the Vector log agent
                               nullable: true
                               type: boolean
                           type: object
@@ -4114,6 +4122,7 @@ spec:
                                 default:
                                   enableVectorAgent: null
                                   containers: {}
+                                description: Logging configuration
                                 properties:
                                   containers:
                                     additionalProperties:
@@ -4121,13 +4130,14 @@ spec:
                                         - required:
                                             - custom
                                         - {}
-                                      description: Fragment derived from `ContainerLogConfigChoice`
+                                      description: Log configuration of the container
                                       properties:
                                         console:
+                                          description: Configuration for the console appender
                                           nullable: true
                                           properties:
                                             level:
-                                              description: Log levels
+                                              description: The log level threshold. Log events with a lower log level are discarded.
                                               enum:
                                                 - TRACE
                                                 - DEBUG
@@ -4143,14 +4153,16 @@ spec:
                                           description: Custom log configuration provided in a ConfigMap
                                           properties:
                                             configMap:
+                                              description: ConfigMap containing the log configuration files
                                               nullable: true
                                               type: string
                                           type: object
                                         file:
+                                          description: Configuration for the file appender
                                           nullable: true
                                           properties:
                                             level:
-                                              description: Log levels
+                                              description: The log level threshold. Log events with a lower log level are discarded.
                                               enum:
                                                 - TRACE
                                                 - DEBUG
@@ -4164,9 +4176,10 @@ spec:
                                           type: object
                                         loggers:
                                           additionalProperties:
+                                            description: Configuration of a logger
                                             properties:
                                               level:
-                                                description: Log levels
+                                                description: The log level threshold. Log events with a lower log level are discarded.
                                                 enum:
                                                   - TRACE
                                                   - DEBUG
@@ -4179,10 +4192,13 @@ spec:
                                                 type: string
                                             type: object
                                           default: {}
+                                          description: Configuration per logger
                                           type: object
                                       type: object
+                                    description: Log configuration per container
                                     type: object
                                   enableVectorAgent:
+                                    description: Wether or not to deploy a container with the Vector log agent
                                     nullable: true
                                     type: boolean
                                 type: object
@@ -7656,6 +7672,7 @@ spec:
                           default:
                             enableVectorAgent: null
                             containers: {}
+                          description: Logging configuration
                           properties:
                             containers:
                               additionalProperties:
@@ -7663,13 +7680,14 @@ spec:
                                   - required:
                                       - custom
                                   - {}
-                                description: Fragment derived from `ContainerLogConfigChoice`
+                                description: Log configuration of the container
                                 properties:
                                   console:
+                                    description: Configuration for the console appender
                                     nullable: true
                                     properties:
                                       level:
-                                        description: Log levels
+                                        description: The log level threshold. Log events with a lower log level are discarded.
                                         enum:
                                           - TRACE
                                           - DEBUG
@@ -7685,14 +7703,16 @@ spec:
                                     description: Custom log configuration provided in a ConfigMap
                                     properties:
                                       configMap:
+                                        description: ConfigMap containing the log configuration files
                                         nullable: true
                                         type: string
                                     type: object
                                   file:
+                                    description: Configuration for the file appender
                                     nullable: true
                                     properties:
                                       level:
-                                        description: Log levels
+                                        description: The log level threshold. Log events with a lower log level are discarded.
                                         enum:
                                           - TRACE
                                           - DEBUG
@@ -7706,9 +7726,10 @@ spec:
                                     type: object
                                   loggers:
                                     additionalProperties:
+                                      description: Configuration of a logger
                                       properties:
                                         level:
-                                          description: Log levels
+                                          description: The log level threshold. Log events with a lower log level are discarded.
                                           enum:
                                             - TRACE
                                             - DEBUG
@@ -7721,10 +7742,13 @@ spec:
                                           type: string
                                       type: object
                                     default: {}
+                                    description: Configuration per logger
                                     type: object
                                 type: object
+                              description: Log configuration per container
                               type: object
                             enableVectorAgent:
+                              description: Wether or not to deploy a container with the Vector log agent
                               nullable: true
                               type: boolean
                           type: object
@@ -11138,6 +11162,7 @@ spec:
                                 default:
                                   enableVectorAgent: null
                                   containers: {}
+                                description: Logging configuration
                                 properties:
                                   containers:
                                     additionalProperties:
@@ -11145,13 +11170,14 @@ spec:
                                         - required:
                                             - custom
                                         - {}
-                                      description: Fragment derived from `ContainerLogConfigChoice`
+                                      description: Log configuration of the container
                                       properties:
                                         console:
+                                          description: Configuration for the console appender
                                           nullable: true
                                           properties:
                                             level:
-                                              description: Log levels
+                                              description: The log level threshold. Log events with a lower log level are discarded.
                                               enum:
                                                 - TRACE
                                                 - DEBUG
@@ -11167,14 +11193,16 @@ spec:
                                           description: Custom log configuration provided in a ConfigMap
                                           properties:
                                             configMap:
+                                              description: ConfigMap containing the log configuration files
                                               nullable: true
                                               type: string
                                           type: object
                                         file:
+                                          description: Configuration for the file appender
                                           nullable: true
                                           properties:
                                             level:
-                                              description: Log levels
+                                              description: The log level threshold. Log events with a lower log level are discarded.
                                               enum:
                                                 - TRACE
                                                 - DEBUG
@@ -11188,9 +11216,10 @@ spec:
                                           type: object
                                         loggers:
                                           additionalProperties:
+                                            description: Configuration of a logger
                                             properties:
                                               level:
-                                                description: Log levels
+                                                description: The log level threshold. Log events with a lower log level are discarded.
                                                 enum:
                                                   - TRACE
                                                   - DEBUG
@@ -11203,10 +11232,13 @@ spec:
                                                 type: string
                                             type: object
                                           default: {}
+                                          description: Configuration per logger
                                           type: object
                                       type: object
+                                    description: Log configuration per container
                                     type: object
                                   enableVectorAgent:
+                                    description: Wether or not to deploy a container with the Vector log agent
                                     nullable: true
                                     type: boolean
                                 type: object

--- a/docs/modules/trino/examples/getting_started/code/trino.yaml
+++ b/docs/modules/trino/examples/getting_started/code/trino.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-trino
 spec:
   image:
-    productVersion: "414"
+    productVersion: "428"
   clusterConfig:
     catalogLabelSelector:
       matchLabels:

--- a/docs/modules/trino/examples/getting_started/code/trino.yaml.j2
+++ b/docs/modules/trino/examples/getting_started/code/trino.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   name: simple-trino
 spec:
   image:
-    productVersion: "414"
+    productVersion: "428"
   clusterConfig:
     catalogLabelSelector:
       matchLabels:

--- a/docs/modules/trino/examples/usage-guide/trino-insecure.yaml
+++ b/docs/modules/trino/examples/usage-guide/trino-insecure.yaml
@@ -17,7 +17,7 @@ metadata:
   name: simple-trino
 spec:
   image:
-    productVersion: "414"
+    productVersion: "428"
   clusterConfig:
     catalogLabelSelector:
       matchLabels:

--- a/docs/modules/trino/examples/usage-guide/trino-secure-internal-tls.yaml
+++ b/docs/modules/trino/examples/usage-guide/trino-secure-internal-tls.yaml
@@ -17,7 +17,7 @@ metadata:
   name: simple-trino
 spec:
   image:
-    productVersion: "414"
+    productVersion: "428"
   clusterConfig:
     tls:
       internalSecretClass: trino-internal-tls # <1>

--- a/docs/modules/trino/examples/usage-guide/trino-secure-tls-only.yaml
+++ b/docs/modules/trino/examples/usage-guide/trino-secure-tls-only.yaml
@@ -17,7 +17,7 @@ metadata:
   name: simple-trino
 spec:
   image:
-    productVersion: "414"
+    productVersion: "428"
   clusterConfig:
     tls:
       serverSecretClass: trino-tls # <1>

--- a/docs/modules/trino/examples/usage-guide/trino-secure-tls.yaml
+++ b/docs/modules/trino/examples/usage-guide/trino-secure-tls.yaml
@@ -17,7 +17,7 @@ metadata:
   name: simple-trino
 spec:
   image:
-    productVersion: "414"
+    productVersion: "428"
   clusterConfig:
     tls:
       serverSecretClass: trino-tls # <1>

--- a/docs/modules/trino/pages/usage-guide/catalogs/index.adoc
+++ b/docs/modules/trino/pages/usage-guide/catalogs/index.adoc
@@ -72,7 +72,7 @@ metadata:
   name: simple-trino
 spec:
   image:
-    productVersion: "414"
+    productVersion: "428"
   clusterConfig:
     catalogLabelSelector:
       matchLabels:

--- a/docs/modules/trino/partials/supported-versions.adoc
+++ b/docs/modules/trino/partials/supported-versions.adoc
@@ -2,9 +2,5 @@
 // This is a separate file, since it is used by both the direct Trino documentation, and the overarching
 // Stackable Platform documentation.
 
-- 377
-- 387
-- 395
-- 396
-- 403
+- 428
 - 414

--- a/examples/simple-trino-cluster-authentication-opa-authorization-s3.yaml
+++ b/examples/simple-trino-cluster-authentication-opa-authorization-s3.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-trino
 spec:
   image:
-    productVersion: "414"
+    productVersion: "428"
   clusterConfig:
     authentication:
       - authenticationClass: simple-trino-users
@@ -51,7 +51,7 @@ metadata:
   name: simple-opa
 spec:
   image:
-    productVersion: 0.45.0
+    productVersion: 0.57.0
   servers:
     roleGroups:
       default: {}

--- a/examples/simple-trino-cluster-hive-ha-s3.yaml
+++ b/examples/simple-trino-cluster-hive-ha-s3.yaml
@@ -9,7 +9,7 @@ metadata:
   name: simple-trino
 spec:
   image:
-    productVersion: "414"
+    productVersion: "428"
   clusterConfig:
     catalogLabelSelector:
       matchLabels:

--- a/examples/simple-trino-cluster-resource-limits.yaml
+++ b/examples/simple-trino-cluster-resource-limits.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-trino
 spec:
   image:
-    productVersion: "414"
+    productVersion: "428"
   clusterConfig:
     catalogLabelSelector: {}
   coordinators:

--- a/examples/simple-trino-cluster-s3.yaml
+++ b/examples/simple-trino-cluster-s3.yaml
@@ -7,7 +7,7 @@ metadata:
   name: simple-trino
 spec:
   image:
-    productVersion: "414"
+    productVersion: "428"
   clusterConfig:
     catalogLabelSelector:
       matchLabels:

--- a/examples/simple-trino-cluster.yaml
+++ b/examples/simple-trino-cluster.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-trino
 spec:
   image:
-    productVersion: "414"
+    productVersion: "428"
   clusterConfig:
     catalogLabelSelector:
       matchLabels:

--- a/rust/crd/src/affinity.rs
+++ b/rust/crd/src/affinity.rs
@@ -107,7 +107,7 @@ mod tests {
           name: simple-trino
         spec:
           image:
-            productVersion: "414"
+            productVersion: "428"
           clusterConfig:
             catalogLabelSelector:
               matchLabels:
@@ -196,7 +196,7 @@ mod tests {
           name: simple-trino
         spec:
           image:
-            productVersion: "414"
+            productVersion: "428"
           clusterConfig:
             catalogLabelSelector:
               matchLabels:
@@ -414,7 +414,7 @@ mod tests {
           name: simple-trino
         spec:
           image:
-            productVersion: "414"
+            productVersion: "428"
           clusterConfig:
             catalogLabelSelector:
               matchLabels:

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -839,7 +839,7 @@ mod tests {
           name: simple-trino
         spec:
           image:
-            productVersion: "414"
+            productVersion: "428"
           clusterConfig:
             catalogLabelSelector: {}
         "#;
@@ -854,7 +854,7 @@ mod tests {
           name: simple-trino
         spec:
           image:
-            productVersion: "414"
+            productVersion: "428"
           clusterConfig:
             catalogLabelSelector: {}
             tls:
@@ -871,7 +871,7 @@ mod tests {
           name: simple-trino
         spec:
           image:
-            productVersion: "414"
+            productVersion: "428"
           clusterConfig:
             catalogLabelSelector: {}
             tls:
@@ -889,7 +889,7 @@ mod tests {
           name: simple-trino
         spec:
           image:
-            productVersion: "414"
+            productVersion: "428"
           clusterConfig:
             catalogLabelSelector: {}
             tls:
@@ -909,7 +909,7 @@ mod tests {
           name: simple-trino
         spec:
           image:
-            productVersion: "414"
+            productVersion: "428"
           clusterConfig:
             catalogLabelSelector: {}
         "#;
@@ -924,7 +924,7 @@ mod tests {
           name: simple-trino
         spec:
           image:
-            productVersion: "414"
+            productVersion: "428"
           clusterConfig:
             catalogLabelSelector: {}
             tls:
@@ -941,7 +941,7 @@ mod tests {
           name: simple-trino
         spec:
           image:
-            productVersion: "414"
+            productVersion: "428"
           clusterConfig:
             catalogLabelSelector: {}
             tls:
@@ -962,7 +962,7 @@ mod tests {
           name: simple-trino
         spec:
           image:
-            productVersion: "414"
+            productVersion: "428"
           clusterConfig:
             catalogLabelSelector: {}
         "#;
@@ -979,7 +979,7 @@ mod tests {
           name: simple-trino
         spec:
           image:
-            productVersion: "414"
+            productVersion: "428"
           clusterConfig:
             catalogLabelSelector: {}
             gracefulShutdownTimeout: 2d
@@ -997,7 +997,7 @@ mod tests {
           name: simple-trino
         spec:
           image:
-            productVersion: "414"
+            productVersion: "428"
           clusterConfig:
             catalogLabelSelector: {}
             gracefulShutdownTimeout: 42 # suffix is missing

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -26,7 +26,6 @@ use stackable_operator::{
         fragment::{self, ValidationError},
         merge::Merge,
     },
-    duration::Duration,
     k8s_openapi::apimachinery::pkg::{api::resource::Quantity, apis::meta::v1::LabelSelector},
     kube::{runtime::reflector::ObjectRef, CustomResource, ResourceExt},
     product_config_utils::{ConfigError, Configuration},
@@ -35,6 +34,7 @@ use stackable_operator::{
     role_utils::{GenericRoleConfig, Role, RoleGroup, RoleGroupRef},
     schemars::{self, JsonSchema},
     status::condition::{ClusterCondition, HasStatusCondition},
+    time::Duration,
 };
 use std::{collections::BTreeMap, str::FromStr};
 use strum::{Display, EnumIter, EnumString, IntoEnumIterator};

--- a/rust/operator-binary/src/authorization/opa.rs
+++ b/rust/operator-binary/src/authorization/opa.rs
@@ -10,7 +10,7 @@ use stackable_operator::{
 };
 use stackable_trino_crd::TrinoCluster;
 
-const PRODUCT_VERSIONS_WITH_OLD_AUTHORIZER: [&str; 5] = ["377", "387", "395", "396", "403"];
+const PRODUCT_VERSIONS_WITH_OLD_AUTHORIZER: [&str; 1] = ["414"];
 
 pub struct TrinoOpaConfig {
     opa_authorizer_name: String,

--- a/tests/templates/kuttl/logging/01-install-trino-vector-aggregator.yaml
+++ b/tests/templates/kuttl/logging/01-install-trino-vector-aggregator.yaml
@@ -5,7 +5,7 @@ commands:
   - script: >-
       helm install trino-vector-aggregator vector
       --namespace $NAMESPACE
-      --version 0.23.0
+      --version 0.26.0
       --repo https://helm.vector.dev
       --values trino-vector-aggregator-values.yaml
 ---

--- a/tests/templates/kuttl/smoke/09-install-opa.yaml.j2
+++ b/tests/templates/kuttl/smoke/09-install-opa.yaml.j2
@@ -12,10 +12,7 @@ spec:
 {% endif %}
   servers:
     roleGroups:
-      default:
-        selector:
-          matchLabels:
-            kubernetes.io/os: linux
+      default: {}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -24,7 +21,7 @@ metadata:
   labels:
     opa.stackable.tech/bundle: "trino"
 data:
-{% if test_scenario['values']['trino'].split('-stackable')[0] in ['377', '387', '395', '396', '403'] %}
+{% if test_scenario['values']['trino'] in ['414'] %}
   trino.rego: |
     package trino
 

--- a/tests/templates/kuttl/smoke/09-install-opa.yaml.j2
+++ b/tests/templates/kuttl/smoke/09-install-opa.yaml.j2
@@ -21,7 +21,7 @@ metadata:
   labels:
     opa.stackable.tech/bundle: "trino"
 data:
-{% if test_scenario['values']['trino'] in ['414'] %}
+{% if test_scenario['values']['trino'] in [414] %}
   trino.rego: |
     package trino
 

--- a/tests/templates/kuttl/smoke/10-install-trino.yaml.j2
+++ b/tests/templates/kuttl/smoke/10-install-trino.yaml.j2
@@ -6,7 +6,6 @@ metadata:
 spec:
   image:
     productVersion: "{{ test_scenario['values']['trino'] }}"
-    pullPolicy: IfNotPresent
   clusterConfig:
     catalogLabelSelector:
       matchLabels:

--- a/tests/templates/kuttl/smoke/10-install-trino.yaml.j2
+++ b/tests/templates/kuttl/smoke/10-install-trino.yaml.j2
@@ -6,6 +6,7 @@ metadata:
 spec:
   image:
     productVersion: "{{ test_scenario['values']['trino'] }}"
+    pullPolicy: IfNotPresent
   clusterConfig:
     catalogLabelSelector:
       matchLabels:

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -13,27 +13,23 @@
 dimensions:
   - name: trino
     values:
-      - 387
-      - 395
-      - 396
-      - 403
       - 414
+      - 428
   - name: trino-latest
     values:
-      - 414
+      - 428
   - name: hive
     values:
-      - 2.3.9
       - 3.1.3
   - name: opa
     values:
-      - 0.51.0
+      - 0.57.0
   - name: hdfs
     values:
-      - 3.3.4
+      - 3.3.6
   - name: zookeeper
     values:
-      - 3.8.1
+      - 3.8.3
   - name: s3-use-tls
     values:
       - "true"


### PR DESCRIPTION
# Description

- added support for 428 with new opa authorizer
- removed support for versions 377, 387, 395, 396, 403
- now opa regos are differentiated in tests for 414 and 428 (old vs new authorizer)
- bumped operator-rs to 0.55.0
- bumped vector to 0.33.0

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
