### PR TITLE
fix: Add core-site.xml when configuring HDFS connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 - Add `core-site.xml` when configuring HDFS connection ([#526]).
 
+[#510]: https://github.com/stackabletech/trino-operator/pull/510
 [#526]: https://github.com/stackabletech/trino-operator/pull/526
 
 ## [23.11.0] - 2023-11-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ All notable changes to this project will be documented in this file.
 
 - Various documentation of the CRD ([#510]).
 
-[#510]: https://github.com/stackabletech/trino-operator/pull/510
+### Fixed
+
+- Add `core-site.xml` when configuring HDFS connection ([#526]).
+
+[#526]: https://github.com/stackabletech/trino-operator/pull/526
 
 ## [23.11.0] - 2023-11-24
 

--- a/rust/operator-binary/src/catalog/commons.rs
+++ b/rust/operator-binary/src/catalog/commons.rs
@@ -179,7 +179,7 @@ impl ExtendCatalogConfig for HdfsConnection {
         let hdfs_site_dir = format!("{CONFIG_DIR_NAME}/catalog/{catalog_name}/hdfs-config");
         catalog_config.add_property(
             "hive.config.resources",
-            format!("{hdfs_site_dir}/hdfs-site.xml"),
+            format!("{hdfs_site_dir}/core-site.xml,{hdfs_site_dir}/hdfs-site.xml"),
         );
 
         let volume_name = format!("{catalog_name}-hdfs");


### PR DESCRIPTION
# Description

Related to https://github.com/stackabletech/trino-operator/issues/525 (not sure if it fixes it)

We already know this was needed when e.g. enabling Kerberos on HDFS, so we would have needed this change in any case in the future.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/style-guide).
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
