### PR TITLE
tests: added namespace patch for openshift tests

### DIFF
--- a/tests/release.yaml
+++ b/tests/release.yaml
@@ -1,7 +1,7 @@
 # Contains all operators required to run the test suite.
 ---
 releases:
-  # Do not change the name of the release as it's referenced from run_tests.sh
+  # Do not change the name of the release as it's referenced from run-tests
   tests:
     releaseDate: 1970-01-01
     description: Integration test

--- a/tests/templates/kuttl/authentication/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/authentication/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/authentication/05-install-test-trino.yaml
+++ b/tests/templates/kuttl/authentication/05-install-test-trino.yaml
@@ -16,8 +16,6 @@ spec:
         app: test-trino
     spec:
       serviceAccount: integration-tests-sa
-      securityContext:
-        fsGroup: 1000
       containers:
         - name: test-trino
           image: docker.stackable.tech/stackable/testing-tools:0.2.0-stackable0.0.0-dev

--- a/tests/templates/kuttl/authentication/05-install-test-trino.yaml.j2
+++ b/tests/templates/kuttl/authentication/05-install-test-trino.yaml.j2
@@ -16,6 +16,10 @@ spec:
         app: test-trino
     spec:
       serviceAccount: integration-tests-sa
+{% if test_scenario['values']['openshift'] == 'false' %}
+      securityContext:
+        fsGroup: 1000
+{% endif %}
       containers:
         - name: test-trino
           image: docker.stackable.tech/stackable/testing-tools:0.2.0-stackable0.0.0-dev

--- a/tests/templates/kuttl/authentication/install-openldap-other.yaml.j2
+++ b/tests/templates/kuttl/authentication/install-openldap-other.yaml.j2
@@ -61,6 +61,13 @@ spec:
           readinessProbe:
             tcpSocket:
               port: 1389
+          # See https://github.com/bitnami/containers/issues/40841#issuecomment-1649977191
+          securityContext:
+           capabilities:
+             drop:
+             - ALL
+             add:
+             - NET_BIND_SERVICE
       volumes:
         - name: tls
           csi:

--- a/tests/templates/kuttl/authentication/install-openldap.yaml.j2
+++ b/tests/templates/kuttl/authentication/install-openldap.yaml.j2
@@ -61,6 +61,13 @@ spec:
           readinessProbe:
             tcpSocket:
               port: 1389
+          # See https://github.com/bitnami/containers/issues/40841#issuecomment-1649977191
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+              add:
+              - NET_BIND_SERVICE
       volumes:
         - name: tls
           csi:

--- a/tests/templates/kuttl/cluster-operation/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/cluster-operation/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/logging/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/logging/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/opa-authorization/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/opa-authorization/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/orphaned-resources/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/orphaned-resources/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/resources/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/resources/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/smoke/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/smoke/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/tls/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/tls/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -77,6 +77,7 @@ tests:
   - name: resources
     dimensions:
       - trino-latest
+      - openshift
   - name: authentication
     dimensions:
       - trino-latest
@@ -85,6 +86,7 @@ tests:
   - name: orphaned-resources
     dimensions:
       - trino-latest
+      - openshift
   - name: logging
     dimensions:
       - trino
@@ -92,6 +94,7 @@ tests:
   - name: cluster-operation
     dimensions:
       - trino-latest
+      - openshift
   - name: opa-authorization
     dimensions:
       - trino-latest


### PR DESCRIPTION
# Description

Part of stackabletech/issues#566.

OKD:

```
--- FAIL: kuttl (1844.11s)
    --- FAIL: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/cluster-operation_trino-latest-442_openshift-true (140.09s)
        --- PASS: kuttl/harness/orphaned-resources_trino-latest-442_openshift-true (89.51s)
        --- PASS: kuttl/harness/logging_trino-442_openshift-true (73.77s)
        --- PASS: kuttl/harness/tls_trino-latest-442_use-authentication-false_use-tls-true_use-internal-tls-true_openshift-true (66.05s)
        --- PASS: kuttl/harness/opa-authorization_trino-latest-442_hive-3.1.3_opa-0.61.0_keycloak-23.0.1_openshift-true (541.64s)
        --- PASS: kuttl/harness/resources_trino-latest-442_openshift-true (91.95s)
        --- FAIL: kuttl/harness/authentication_trino-latest-442_ldap-use-tls-true_openshift-true (310.33s)
        --- FAIL: kuttl/harness/smoke_trino-442_hive-3.1.3_opa-0.61.0_hdfs-3.3.6_zookeeper-3.9.1_s3-use-tls-true_openshift-true (1465.54s)

# Reruns:
--- PASS: kuttl (618.39s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_trino-442_hive-3.1.3_opa-0.61.0_hdfs-3.3.6_zookeeper-3.9.1_s3-use-tls-true_openshift-true (609.31s)
--- PASS: kuttl (325.72s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/authentication_trino-latest-442_ldap-use-tls-true_openshift-true (316.75s)

```


Azure:

```
--- PASS: kuttl (1398.40s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/logging_trino-442_openshift-false (96.87s)
        --- PASS: kuttl/harness/tls_trino-latest-442_use-authentication-true_use-tls-false_use-internal-tls-true_openshift-false (68.02s)
        --- PASS: kuttl/harness/authentication_trino-latest-442_ldap-use-tls-true_openshift-false (273.91s)
        --- PASS: kuttl/harness/opa-authorization_trino-latest-442_hive-3.1.3_opa-0.61.0_keycloak-23.0.1_openshift-false (450.17s)
        --- PASS: kuttl/harness/resources_trino-latest-442_openshift-false (82.24s)
        --- PASS: kuttl/harness/cluster-operation_trino-latest-442_openshift-false (93.74s)
        --- PASS: kuttl/harness/tls_trino-latest-442_use-authentication-true_use-tls-true_use-internal-tls-true_openshift-false (73.96s)
        --- PASS: kuttl/harness/authentication_trino-latest-442_ldap-use-tls-false_openshift-false (300.08s)
        --- PASS: kuttl/harness/tls_trino-latest-442_use-authentication-true_use-tls-true_use-internal-tls-false_openshift-false (58.25s)
        --- PASS: kuttl/harness/tls_trino-latest-442_use-authentication-false_use-tls-true_use-internal-tls-false_openshift-false (59.55s)
        --- PASS: kuttl/harness/tls_trino-latest-442_use-authentication-true_use-tls-false_use-internal-tls-false_openshift-false (50.70s)
        --- PASS: kuttl/harness/tls_trino-latest-442_use-authentication-false_use-tls-true_use-internal-tls-true_openshift-false (62.54s)
        --- PASS: kuttl/harness/tls_trino-latest-442_use-authentication-false_use-tls-false_use-internal-tls-false_openshift-false (53.54s)
        --- PASS: kuttl/harness/orphaned-resources_trino-latest-442_openshift-false (65.73s)
        --- PASS: kuttl/harness/tls_trino-latest-442_use-authentication-false_use-tls-false_use-internal-tls-true_openshift-false (73.18s)
        --- PASS: kuttl/harness/smoke_trino-442_hive-3.1.3_opa-0.61.0_hdfs-3.3.6_zookeeper-3.9.1_s3-use-tls-true_openshift-false (467.17s)
```


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
