### PR TITLE
Adapt the expected error type in TLS tests

### DIFF
--- a/tests/templates/kuttl/tls/check-tls.py
+++ b/tests/templates/kuttl/tls/check-tls.py
@@ -84,13 +84,13 @@ if __name__ == '__main__':
     # We expect these to fail
     if conf["useAuthentication"]:
         conn = get_authenticated_https_connection(coordinator_host, "admin", "admin", untrusted_ca)
-        test_query_failure(conn, query, requests.exceptions.SSLError, "Could connect with wrong certificate")
+        test_query_failure(conn, query, trino.exceptions.TrinoConnectionError, "Could connect with wrong certificate")
         conn = get_authenticated_https_connection(coordinator_host, "admin", "wrong_password", trusted_ca)
         test_query_failure(conn, query, trino.exceptions.HttpError, "Could connect with wrong password")
         conn = get_authenticated_https_connection(coordinator_host, "wrong_user", "wrong_password", trusted_ca)
         test_query_failure(conn, query, trino.exceptions.HttpError, "Could connect with wrong user and password")
     elif conf["useTls"]:
         conn = get_https_connection(coordinator_host, "admin", untrusted_ca)
-        test_query_failure(conn, query, requests.exceptions.SSLError, "Could connect with wrong certificate")
+        test_query_failure(conn, query, trino.exceptions.TrinoConnectionError, "Could connect with wrong certificate")
 
     print("All TLS tests finished successfully!")


### PR DESCRIPTION
# Description

The PR https://github.com/stackabletech/docker-images/pull/662 bumped the trino python client from 0.322.0 to 0.328.0

In 0.327.0 was a change:
```
Raise TrinoConnectionError for all connection related errors.
```
https://github.com/trinodb/trino-python-client/blob/master/CHANGES.md#release-03270

This PR just changes the expected error type.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
