### PR TITLE
feat: Support non-default cluster domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Added support for Trino 455 ([#638]).
+- The operator can now run on Kubernetes clusters using a non-default cluster domain. It should automatically detect the
+  correct domain to use, but you can also use the env var `KUBERNETES_CLUSTER_DOMAIN` to set the domain explicitly
+  or use the helm-chart property `kubernetesClusterDomain` ([#xxx]).
 
 ### Changed
 
@@ -29,6 +32,7 @@ All notable changes to this project will be documented in this file.
 [#634]: https://github.com/stackabletech/trino-operator/pull/634
 [#638]: https://github.com/stackabletech/trino-operator/pull/638
 [#646]: https://github.com/stackabletech/trino-operator/pull/646
+[#xxx]: https://github.com/stackabletech/trino-operator/pull/xxx
 
 ## [24.7.0] - 2024-07-24
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2194,8 +2194,8 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stackable-operator"
-version = "0.77.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.77.1#cb4460f38f092ce8b9bc7452efcdd1ccde39f14a"
+version = "0.79.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.79.0#a2ac5f525edfd9a2fab884ba753e79a325fbb752"
 dependencies = [
  "chrono",
  "clap",
@@ -2220,6 +2220,7 @@ dependencies = [
  "serde_yaml",
  "snafu 0.8.5",
  "stackable-operator-derive",
+ "stackable-shared",
  "strum",
  "tokio",
  "tracing",
@@ -2232,12 +2233,24 @@ dependencies = [
 [[package]]
 name = "stackable-operator-derive"
 version = "0.3.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.77.1#cb4460f38f092ce8b9bc7452efcdd1ccde39f14a"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.79.0#a2ac5f525edfd9a2fab884ba753e79a325fbb752"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.79",
+]
+
+[[package]]
+name = "stackable-shared"
+version = "0.0.1"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.79.0#a2ac5f525edfd9a2fab884ba753e79a325fbb752"
+dependencies = [
+ "kube",
+ "semver",
+ "serde",
+ "serde_yaml",
+ "snafu 0.8.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 snafu = "0.8"
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.77.1" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.79.0" }
 product-config = { git = "https://github.com/stackabletech/product-config.git", tag = "0.7.0" }
 strum = { version = "0.26", features = ["derive"] }
 tokio = { version = "1.40", features = ["full"] }

--- a/deploy/helm/trino-operator/values.yaml
+++ b/deploy/helm/trino-operator/values.yaml
@@ -47,3 +47,8 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# When running on a non-default Kubernetes cluster domain and the auto detection is not working correctly,
+# you can set your custom cluster domain here.
+# See the https://docs.stackable.tech/home/stable/guides/kubernetes-cluster-domain guide for details
+# kubernetesClusterDomain: my-cluster.local

--- a/rust/crd/src/discovery.rs
+++ b/rust/crd/src/discovery.rs
@@ -1,3 +1,5 @@
+use stackable_operator::utils::cluster_domain::KUBERNETES_CLUSTER_DOMAIN;
+
 use crate::{HTTPS_PORT, HTTP_PORT};
 
 /// Reference to a single `Pod` that is a component of a [`crate::TrinoCluster`]
@@ -10,9 +12,12 @@ pub struct TrinoPodRef {
 
 impl TrinoPodRef {
     pub fn fqdn(&self) -> String {
+        let cluster_domain = KUBERNETES_CLUSTER_DOMAIN
+            .get()
+            .expect("KUBERNETES_CLUSTER_DOMAIN must first be set by calling initialize_operator");
         format!(
-            "{}.{}.{}.svc.cluster.local",
-            self.pod_name, self.role_group_service_name, self.namespace
+            "{}.{}.{}.svc.{}",
+            self.pod_name, self.role_group_service_name, self.namespace, cluster_domain
         )
     }
 }

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -653,10 +653,14 @@ impl TrinoCluster {
     }
 
     pub fn role_service_fqdn(&self, role: &TrinoRole) -> Result<String, Error> {
+        let cluster_domain = KUBERNETES_CLUSTER_DOMAIN
+            .get()
+            .expect("KUBERNETES_CLUSTER_DOMAIN must first be set by calling initialize_operator");
         Ok(format!(
-            "{}.{}.svc.cluster.local",
+            "{}.{}.svc.{}",
             self.role_service_name(role)?,
-            self.namespace_r()?
+            self.namespace_r()?,
+            cluster_domain
         ))
     }
 

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -71,7 +71,8 @@ async fn main() -> anyhow::Result<()> {
             ])?;
 
             let client =
-                stackable_operator::client::create_client(Some(OPERATOR_NAME.to_string())).await?;
+                stackable_operator::client::initialize_operator(Some(OPERATOR_NAME.to_string()))
+                    .await?;
 
             let cluster_controller = Controller::new(
                 watch_namespace.get_api::<TrinoCluster>(&client),


### PR DESCRIPTION
# Description

- bump to op-rs 0.79
- make cluster domain configurable

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
