### PR TITLE
fix: Construction of OIDC endpoint when rootPath has a trailing slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to this project will be documented in this file.
 - Don't ignore envOverrides ([#633]).
 - Don't print credentials to STDOUT during startup. Ideally we should use [config-utils](https://github.com/stackabletech/config-utils), but that's not easy (see [here](https://github.com/stackabletech/trino-operator/tree/fix/secret-printing)) ([#634]).
 - Invalid `TrinoCluster`, `TrinoCatalog` or `AuthenticationClass` objects don't stop the operator from reconciliation ([#657])
-- Fix OIDC endpoint calculation in case the `rootPath` does have a trailing slash ([#XXX]).
+- Fix OIDC endpoint calculation in case the `rootPath` does have a trailing slash ([#673]).
 
 ### Removed
 
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.
 [#646]: https://github.com/stackabletech/trino-operator/pull/646
 [#655]: https://github.com/stackabletech/trino-operator/pull/655
 [#657]: https://github.com/stackabletech/trino-operator/pull/657
+[#673]: https://github.com/stackabletech/trino-operator/pull/673
 
 ## [24.7.0] - 2024-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - Don't ignore envOverrides ([#633]).
 - Don't print credentials to STDOUT during startup. Ideally we should use [config-utils](https://github.com/stackabletech/config-utils), but that's not easy (see [here](https://github.com/stackabletech/trino-operator/tree/fix/secret-printing)) ([#634]).
 - Invalid `TrinoCluster`, `TrinoCatalog` or `AuthenticationClass` objects don't stop the operator from reconciliation ([#657])
+- Fix OIDC endpoint calculation in case the `rootPath` does have a trailing slash ([#XXX]).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to this project will be documented in this file.
 - Don't ignore envOverrides ([#633]).
 - Don't print credentials to STDOUT during startup. Ideally we should use [config-utils](https://github.com/stackabletech/config-utils), but that's not easy (see [here](https://github.com/stackabletech/trino-operator/tree/fix/secret-printing)) ([#634]).
 - Invalid `TrinoCluster`, `TrinoCatalog` or `AuthenticationClass` objects don't stop the operator from reconciliation ([#657])
-- Fix OIDC endpoint calculation in case the `rootPath` does have a trailing slash ([#673]).
+- Fix OIDC endpoint construction in case the `rootPath` does have a trailing slash ([#673]).
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2225,8 +2225,8 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stackable-operator"
-version = "0.81.0"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=fix%2Foidc-endpoint-calculation#9cea26304fdefc42753c34f3e3554e9c63625016"
+version = "0.82.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.82.0#415bbd031bd52e9c0c5392060235030e9930b46b"
 dependencies = [
  "chrono",
  "clap",
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator-derive"
 version = "0.3.1"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=fix%2Foidc-endpoint-calculation#9cea26304fdefc42753c34f3e3554e9c63625016"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.82.0#415bbd031bd52e9c0c5392060235030e9930b46b"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2275,7 +2275,7 @@ dependencies = [
 [[package]]
 name = "stackable-shared"
 version = "0.0.1"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=fix%2Foidc-endpoint-calculation#9cea26304fdefc42753c34f3e3554e9c63625016"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.82.0#415bbd031bd52e9c0c5392060235030e9930b46b"
 dependencies = [
  "kube",
  "semver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2225,8 +2225,8 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stackable-operator"
-version = "0.80.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.80.0#6fbe32300b60f95e0baa2ab0ff2daf961b06531c"
+version = "0.81.0"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=fix%2Foidc-endpoint-calculation#9cea26304fdefc42753c34f3e3554e9c63625016"
 dependencies = [
  "chrono",
  "clap",
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator-derive"
 version = "0.3.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.80.0#6fbe32300b60f95e0baa2ab0ff2daf961b06531c"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=fix%2Foidc-endpoint-calculation#9cea26304fdefc42753c34f3e3554e9c63625016"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2275,7 +2275,7 @@ dependencies = [
 [[package]]
 name = "stackable-shared"
 version = "0.0.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.80.0#6fbe32300b60f95e0baa2ab0ff2daf961b06531c"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=fix%2Foidc-endpoint-calculation#9cea26304fdefc42753c34f3e3554e9c63625016"
 dependencies = [
  "kube",
  "semver",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -6816,13 +6816,13 @@ rec {
       };
       "stackable-operator" = rec {
         crateName = "stackable-operator";
-        version = "0.80.0";
+        version = "0.82.0";
         edition = "2021";
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "6fbe32300b60f95e0baa2ab0ff2daf961b06531c";
-          sha256 = "16jrq3wdwz63210jgmqbx3snrr15wxw6l1smqhzv7b7jpq8qvya3";
+          rev = "415bbd031bd52e9c0c5392060235030e9930b46b";
+          sha256 = "0phasjwb64rxgn5hs8vks92icmx9255bd5v9dms280clrfpcg4hy";
         };
         libName = "stackable_operator";
         authors = [
@@ -6979,8 +6979,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "6fbe32300b60f95e0baa2ab0ff2daf961b06531c";
-          sha256 = "16jrq3wdwz63210jgmqbx3snrr15wxw6l1smqhzv7b7jpq8qvya3";
+          rev = "415bbd031bd52e9c0c5392060235030e9930b46b";
+          sha256 = "0phasjwb64rxgn5hs8vks92icmx9255bd5v9dms280clrfpcg4hy";
         };
         procMacro = true;
         libName = "stackable_operator_derive";
@@ -7014,8 +7014,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "6fbe32300b60f95e0baa2ab0ff2daf961b06531c";
-          sha256 = "16jrq3wdwz63210jgmqbx3snrr15wxw6l1smqhzv7b7jpq8qvya3";
+          rev = "415bbd031bd52e9c0c5392060235030e9930b46b";
+          sha256 = "0phasjwb64rxgn5hs8vks92icmx9255bd5v9dms280clrfpcg4hy";
         };
         libName = "stackable_shared";
         authors = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,12 +24,12 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 snafu = "0.8"
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.80.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.82.0" }
 product-config = { git = "https://github.com/stackabletech/product-config.git", tag = "0.7.0" }
 strum = { version = "0.26", features = ["derive"] }
 tokio = { version = "1.40", features = ["full"] }
 tracing = "0.1"
 
-[patch."https://github.com/stackabletech/operator-rs.git"]
-stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "fix/oidc-endpoint-calculation" }
+# [patch."https://github.com/stackabletech/operator-rs.git"]
+# stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "main" }
 # stackable-operator = { path = "../operator-rs/crates/stackable-operator" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,6 @@ strum = { version = "0.26", features = ["derive"] }
 tokio = { version = "1.40", features = ["full"] }
 tracing = "0.1"
 
-# [patch."https://github.com/stackabletech/operator-rs.git"]
-# stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "main" }
+[patch."https://github.com/stackabletech/operator-rs.git"]
+stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "fix/oidc-endpoint-calculation" }
 # stackable-operator = { path = "../operator-rs/crates/stackable-operator" }

--- a/crate-hashes.json
+++ b/crate-hashes.json
@@ -1,6 +1,6 @@
 {
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.80.0#stackable-operator-derive@0.3.1": "16jrq3wdwz63210jgmqbx3snrr15wxw6l1smqhzv7b7jpq8qvya3",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.80.0#stackable-operator@0.80.0": "16jrq3wdwz63210jgmqbx3snrr15wxw6l1smqhzv7b7jpq8qvya3",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.80.0#stackable-shared@0.0.1": "16jrq3wdwz63210jgmqbx3snrr15wxw6l1smqhzv7b7jpq8qvya3",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.82.0#stackable-operator-derive@0.3.1": "0phasjwb64rxgn5hs8vks92icmx9255bd5v9dms280clrfpcg4hy",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.82.0#stackable-operator@0.82.0": "0phasjwb64rxgn5hs8vks92icmx9255bd5v9dms280clrfpcg4hy",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.82.0#stackable-shared@0.0.1": "0phasjwb64rxgn5hs8vks92icmx9255bd5v9dms280clrfpcg4hy",
   "git+https://github.com/stackabletech/product-config.git?tag=0.7.0#product-config@0.7.0": "0gjsm80g6r75pm3824dcyiz4ysq1ka4c1if6k1mjm9cnd5ym0gny"
 }

--- a/docs/modules/trino/examples/usage-guide/trino-oidc-auth-snippet.yaml
+++ b/docs/modules/trino/examples/usage-guide/trino-oidc-auth-snippet.yaml
@@ -21,7 +21,7 @@ spec:
     oidc:
       hostname: keycloak.default.svc.cluster.local
       port: 8080
-      rootPath: /realms/stackable
+      rootPath: /realms/stackable/
       scopes:
       - openid
       principalClaim: preferred_username

--- a/examples/simple-trino-oauth2.yaml
+++ b/examples/simple-trino-oauth2.yaml
@@ -53,7 +53,7 @@ spec:
     oidc:
       hostname: keycloak
       port: 8080
-      rootPath: /realms/stackable
+      rootPath: /realms/stackable/
       scopes: ["openid"]
       principalClaim: preferred_username
 ---

--- a/rust/crd/src/authentication.rs
+++ b/rust/crd/src/authentication.rs
@@ -25,7 +25,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 pub struct ResolvedAuthenticationClassRef {
     /// An [AuthenticationClass](DOCS_BASE_URL_PLACEHOLDER/concepts/authentication) to use.
     pub authentication_class: AuthenticationClass,
-    pub oidc: Option<oidc::ClientAuthenticationOptions>,
+    pub client_auth_options: Option<oidc::ClientAuthenticationOptions>,
 }
 
 /// Retrieve all provided AuthenticationClass references.
@@ -43,7 +43,7 @@ pub async fn resolve_authentication_classes(
         let auth_class_name = resolved_auth_class.name_any();
 
         resolved_auth_classes.push(ResolvedAuthenticationClassRef {
-            oidc: match &resolved_auth_class.spec.provider {
+            client_auth_options: match &resolved_auth_class.spec.provider {
                 AuthenticationClassProvider::Oidc(_) => Some(
                     client_authentication_detail
                         .oidc_or_error(&auth_class_name)

--- a/rust/operator-binary/src/authentication/mod.rs
+++ b/rust/operator-binary/src/authentication/mod.rs
@@ -508,7 +508,7 @@ impl TryFrom<Vec<ResolvedAuthenticationClassRef>> for TrinoAuthenticationTypes {
                     );
                 }
                 AuthenticationClassProvider::Oidc(provider) => {
-                    let oidc = resolved_auth_class.oidc.context(
+                    let oidc = resolved_auth_class.client_auth_options.context(
                         OidcAuthenticationDetailsNotSpecifiedSnafu {
                             auth_class_name: auth_class_name.clone(),
                         },
@@ -591,7 +591,7 @@ mod tests {
 
         ResolvedAuthenticationClassRef {
             authentication_class: input,
-            oidc: None,
+            client_auth_options: None,
         }
     }
 
@@ -610,7 +610,7 @@ mod tests {
 
         ResolvedAuthenticationClassRef {
             authentication_class: input,
-            oidc: None,
+            client_auth_options: None,
         }
     }
 
@@ -636,7 +636,7 @@ mod tests {
 
         ResolvedAuthenticationClassRef {
             authentication_class: input,
-            oidc: None,
+            client_auth_options: None,
         }
     }
 
@@ -663,7 +663,7 @@ mod tests {
                 deserializer,
             )
             .unwrap(),
-            oidc: Some(ClientAuthenticationOptions {
+            client_auth_options: Some(ClientAuthenticationOptions {
                 client_credentials_secret_ref: "my-oidc-secret".to_string(),
                 extra_scopes: Vec::new(),
                 product_specific_fields: (),

--- a/rust/operator-binary/src/authentication/mod.rs
+++ b/rust/operator-binary/src/authentication/mod.rs
@@ -651,7 +651,7 @@ mod tests {
               provider:
                 oidc:
                   hostname: {HOST_NAME}
-                  rootPath: /realms/master
+                  rootPath: /realms/master/
                   scopes: ["openid"]
                   principalClaim: preferred_username
             "#,

--- a/tests/templates/kuttl/authentication/create-authentication-classes.yaml.j2
+++ b/tests/templates/kuttl/authentication/create-authentication-classes.yaml.j2
@@ -8,7 +8,7 @@ spec:
     oidc:
       hostname: keycloak.$NAMESPACE.svc.cluster.local
       port: 8443
-      rootPath: /realms/stackable
+      rootPath: /realms/stackable/
       scopes:
         - openid
       principalClaim: preferred_username


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/operator-rs/pull/910

Before this PR the operator generated
`http-server.authentication.oauth2.issuer=https\://185.56.150.115\:30584/realms/demo/`
resulting in
`java.lang.IllegalStateException: Invalid response from OpenID Metadata endpoint. The value of the "issuer" claim in Metadata document different than the Issuer URL used for the Configuration Request.`

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
