### PR TITLE
feat: Add access-control.properties overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Support configuring JVM arguments ([#677]).
 - Aggregate emitted Kubernetes events on the CustomResources ([#677]).
 - Support for Trino 470 ([#705]).
+- Support `access-control.properties` in configOverrides ([#721]).
 
 ### Changed
 
@@ -39,6 +40,7 @@ All notable changes to this project will be documented in this file.
 [#705]: https://github.com/stackabletech/trino-operator/pull/705
 [#715]: https://github.com/stackabletech/trino-operator/pull/715
 [#717]: https://github.com/stackabletech/trino-operator/pull/717
+[#721]: https://github.com/stackabletech/trino-operator/pull/721
 
 ## [24.11.1] - 2025-01-10
 

--- a/docs/modules/trino/pages/usage-guide/configuration.adoc
+++ b/docs/modules/trino/pages/usage-guide/configuration.adoc
@@ -10,9 +10,9 @@ This will lead to faulty installations.
 
 For a role or role group, at the same level of `config`, you can specify `configOverrides` for:
 
+* `access-control.properties`
 * `config.properties`
 * `node.properties`
-* `log.properties`
 * `password-authenticator.properties`
 * `security.properties`
 

--- a/rust/operator-binary/src/authorization/opa.rs
+++ b/rust/operator-binary/src/authorization/opa.rs
@@ -10,24 +10,24 @@ use crate::crd::v1alpha1::TrinoCluster;
 pub struct TrinoOpaConfig {
     /// URI for OPA policies, e.g.
     /// `http://localhost:8081/v1/data/trino/allow`
-    non_batched_connection_string: String,
+    pub(crate) non_batched_connection_string: String,
     /// URI for Batch OPA policies, e.g.
     /// `http://localhost:8081/v1/data/trino/batch` - if not set, a
     /// single request will be sent for each entry on filtering methods
-    batched_connection_string: String,
+    pub(crate) batched_connection_string: String,
     /// URI for fetching row filters, e.g.
     /// `http://localhost:8081/v1/data/trino/rowFilters` - if not set,
     /// no row filtering will be applied
-    row_filters_connection_string: Option<String>,
+    pub(crate) row_filters_connection_string: Option<String>,
     /// URI for fetching column masks, e.g.
     /// `http://localhost:8081/v1/data/trino/columnMask` - if not set,
     /// no masking will be applied
-    column_masking_connection_string: Option<String>,
+    pub(crate) column_masking_connection_string: Option<String>,
     /// Whether to allow permission management (GRANT, DENY, ...) and
     /// role management operations - OPA will not be queried for any
     /// such operations, they will be bulk allowed or denied depending
     /// on this setting
-    allow_permission_management_operations: bool,
+    pub(crate) allow_permission_management_operations: bool,
 }
 
 impl TrinoOpaConfig {

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -746,12 +746,15 @@ fn build_rolegroup_config_map(
                 // Add static properties and overrides
                 dynamic_resolved_config.extend(transformed_config);
 
-                let access_control_properties = product_config::writer::to_java_properties_string(
-                    dynamic_resolved_config.iter(),
-                )
-                .context(FailedToWriteJavaPropertiesSnafu)?;
+                if !dynamic_resolved_config.is_empty() {
+                    let access_control_properties =
+                        product_config::writer::to_java_properties_string(
+                            dynamic_resolved_config.iter(),
+                        )
+                        .context(FailedToWriteJavaPropertiesSnafu)?;
 
-                cm_conf_data.insert(file_name.to_string(), access_control_properties);
+                    cm_conf_data.insert(file_name.to_string(), access_control_properties);
+                }
             }
             PropertyNameKind::File(file_name) if file_name == JVM_CONFIG => {}
             _ => {}

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -1838,14 +1838,14 @@ mod tests {
               access-control.properties:
                 hello-from-role: "true" # only defined here at role level
                 foo.bar: "false" # overriden by role group below
-                opa.allow-permission-management-operations: "false" # override logging value from config
+                opa.allow-permission-management-operations: "false" # override value from config
             roleGroups:
               default:
                 configOverrides:
                   access-control.properties:
                     hello-from-role-group: "true" # only defined here at group level
                     foo.bar: "true" # overrides role value
-                    opa.policy.batched-uri: "http://simple-opa.default.svc.cluster.local:8081/v1/data/my-product/batch-new" # override logging value from config
+                    opa.policy.batched-uri: "http://simple-opa.default.svc.cluster.local:8081/v1/data/my-product/batch-new" # override value from config
                 replicas: 1
           workers:
             roleGroups:


### PR DESCRIPTION
# Description

Implementation for https://github.com/stackabletech/trino-operator/issues/692

```
--- FAIL: kuttl (1731.56s)
    --- FAIL: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/cluster-operation_trino-latest-470_openshift-false (73.45s)
        --- PASS: kuttl/harness/tls_trino-latest-470_use-authentication-false_use-tls-true_use-internal-tls-true_openshift-false (73.56s)
        --- PASS: kuttl/harness/logging_trino-470_openshift-false (70.66s)
        --- PASS: kuttl/harness/authentication_trino-latest-470_ldap-use-tls-false_openshift-false (265.89s)
        --- PASS: kuttl/harness/logging_trino-455_openshift-false (69.92s)
        --- PASS: kuttl/harness/logging_trino-451_openshift-false (72.95s)
        --- PASS: kuttl/harness/tls_trino-latest-470_use-authentication-true_use-tls-true_use-internal-tls-true_openshift-false (75.16s)
        --- PASS: kuttl/harness/tls_trino-latest-470_use-authentication-true_use-tls-true_use-internal-tls-false_openshift-false (73.80s)
        --- PASS: kuttl/harness/smoke_trino-451_hive-3.1.3_opa-1.0.1_hdfs-3.4.0_zookeeper-3.9.2_openshift-false (507.71s)
        --- PASS: kuttl/harness/tls_trino-latest-470_use-authentication-true_use-tls-false_use-internal-tls-true_openshift-false (74.19s)
        --- PASS: kuttl/harness/tls_trino-latest-470_use-authentication-true_use-tls-false_use-internal-tls-false_openshift-false (68.22s)
        --- PASS: kuttl/harness/resources_trino-latest-470_openshift-false (57.70s)
        --- PASS: kuttl/harness/orphaned-resources_trino-latest-470_openshift-false (44.74s)
        --- PASS: kuttl/harness/authentication_trino-latest-470_ldap-use-tls-true_openshift-false (282.77s)
        --- FAIL: kuttl/harness/opa-authorization_trino-latest-470_hive-latest-4.0.0_opa-1.0.1_keycloak-25.0.0_openshift-false (595.17s)
        --- PASS: kuttl/harness/smoke_trino-455_hive-4.0.0_opa-1.0.1_hdfs-3.4.0_zookeeper-3.9.2_openshift-false (362.55s)
        --- PASS: kuttl/harness/smoke_trino-470_hive-3.1.3_opa-1.0.1_hdfs-3.4.0_zookeeper-3.9.2_openshift-false (394.00s)
        --- PASS: kuttl/harness/smoke_trino-455_hive-3.1.3_opa-1.0.1_hdfs-3.4.0_zookeeper-3.9.2_openshift-false (401.31s)
        --- PASS: kuttl/harness/tls_trino-latest-470_use-authentication-false_use-tls-false_use-internal-tls-true_openshift-false (71.47s)
        --- PASS: kuttl/harness/tls_trino-latest-470_use-authentication-false_use-tls-true_use-internal-tls-false_openshift-false (72.76s)
        --- PASS: kuttl/harness/smoke_trino-451_hive-4.0.0_opa-1.0.1_hdfs-3.4.0_zookeeper-3.9.2_openshift-false (383.24s)
        --- PASS: kuttl/harness/tls_trino-latest-470_use-authentication-false_use-tls-false_use-internal-tls-false_openshift-false (69.02s)
        --- PASS: kuttl/harness/smoke_trino-470_hive-4.0.0_opa-1.0.1_hdfs-3.4.0_zookeeper-3.9.2_openshift-false (407.38s)
FAIL
ERROR:root:kuttl failed
```
TODO: Failing integration test needs to run again after fix https://github.com/stackabletech/trino-operator/pull/720

```
--- PASS: kuttl (284.31s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/opa-authorization_trino-latest-470_hive-latest-4.0.0_opa-1.0.1_keycloak-25.0.0_openshift-false (284.30s)
PASS
```

## Definition of Done Checklist

```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [x] Code contains useful comments
- [ ] Code contains useful logging statements
- [x] (Integration-)Test cases added
- [x] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
