### PR TITLE
docs: Mark Trino 455 as deprecated

### DIFF
--- a/docs/modules/trino/partials/supported-versions.adoc
+++ b/docs/modules/trino/partials/supported-versions.adoc
@@ -3,5 +3,5 @@
 // Stackable Platform documentation.
 
 - 470
-- 455
+- 455 (deprecated)
 - 451 (LTS)


### PR DESCRIPTION
Part of <https://github.com/stackabletech/docker-images/issues/971>.

Mark Trino 455 as deprecated.

Related PR: https://github.com/stackabletech/trino-operator/pull/725