### PR TITLE
chore: expand opa-authorization test to run with all supported trino versions

### DIFF
--- a/tests/templates/kuttl/opa-authorization/20-install-trino.yaml.j2
+++ b/tests/templates/kuttl/opa-authorization/20-install-trino.yaml.j2
@@ -5,11 +5,11 @@ metadata:
   name: trino
 spec:
   image:
-{% if test_scenario['values']['trino-latest'].find(",") > 0 %}
-    custom: "{{ test_scenario['values']['trino-latest'].split(',')[1] }}"
-    productVersion: "{{ test_scenario['values']['trino-latest'].split(',')[0] }}"
+{% if test_scenario['values']['trino'].find(",") > 0 %}
+    custom: "{{ test_scenario['values']['trino'].split(',')[1] }}"
+    productVersion: "{{ test_scenario['values']['trino'].split(',')[0] }}"
 {% else %}
-    productVersion: "{{ test_scenario['values']['trino-latest'] }}"
+    productVersion: "{{ test_scenario['values']['trino'] }}"
 {% endif %}
     pullPolicy: IfNotPresent
   clusterConfig:

--- a/tests/templates/kuttl/opa-authorization/check-opa.py.j2
+++ b/tests/templates/kuttl/opa-authorization/check-opa.py.j2
@@ -51,7 +51,11 @@ TEST_DATA = [
             {
                 "query": "SET SESSION iceberg.test=true",
                 # The requests are authorized, just a fake property
+{% if test_scenario['values']['trino'] == '470' %}
                 "error": "Session property iceberg.test does not exist",
+{% else %}
+                "error": "Session property 'iceberg.test' does not exist",
+{% endif %}
             },
             # ## SCHEMA ##
             # ExecuteQuery, AccessCatalog, ShowSchemas, SelectFromColumns, FilterCatalogs, FilterSchemas

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -106,7 +106,7 @@ tests:
       - openshift
   - name: opa-authorization
     dimensions:
-      - trino-latest
+      - trino
       - hive-latest
       - opa
       - keycloak


### PR DESCRIPTION
# Description

Follow up of this comment https://github.com/stackabletech/trino-operator/pull/720#pullrequestreview-2681191722
Run opa-authorization tests for all supported Trino versions.

```
--- PASS: kuttl (320.63s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/opa-authorization_trino-455_hive-latest-4.0.1_opa-1.0.1_keycloak-25.0.0_openshift-false (307.00s)
        --- PASS: kuttl/harness/opa-authorization_trino-470_hive-latest-4.0.1_opa-1.0.1_keycloak-25.0.0_openshift-false (310.35s)
        --- PASS: kuttl/harness/opa-authorization_trino-451_hive-latest-4.0.1_opa-1.0.1_keycloak-25.0.0_openshift-false (320.62s)
PASS
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
