### PR TITLE
test: Bump HDFS to 3.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
   - Replace stackable-operator `print_startup_string` with `tracing::info!` with fields.
 - BREAKING: Inject the vector aggregator address into the vector config using the env var `VECTOR_AGGREGATOR_ADDRESS` instead
     of having the operator write it to the vector config ([#734]).
+- test: Bump HDFS to `3.4.1` ([#741]).
 
 ### Fixed
 
@@ -32,6 +33,7 @@ All notable changes to this project will be documented in this file.
 [#733]: https://github.com/stackabletech/trino-operator/pull/733
 [#735]: https://github.com/stackabletech/trino-operator/pull/735
 [#739]: https://github.com/stackabletech/trino-operator/pull/739
+[#741]: https://github.com/stackabletech/trino-operator/pull/741
 
 ## [25.3.0] - 2025-03-21
 

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -41,7 +41,7 @@ dimensions:
       - 1.0.1
   - name: hdfs
     values:
-      - 3.4.0
+      - 3.4.1
   - name: zookeeper
     values:
       - 3.9.3


### PR DESCRIPTION
Part of https://github.com/stackabletech/hdfs-operator/pull/675.

- Bump HDFS to 3.4.1

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

# Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible

# Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

# Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
