### PR TITLE
test: Bump OPA to 1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
     of having the operator write it to the vector config ([#734]).
 - test: Bump HDFS to `3.4.1` ([#741]).
 - test: Bump to Vector `0.46.1` ([#743]).
+- test: Bump OPA `1.4.2` ([#745]).
 
 ### Fixed
 
@@ -36,6 +37,7 @@ All notable changes to this project will be documented in this file.
 [#739]: https://github.com/stackabletech/trino-operator/pull/739
 [#741]: https://github.com/stackabletech/trino-operator/pull/741
 [#743]: https://github.com/stackabletech/trino-operator/pull/743
+[#745]: https://github.com/stackabletech/trino-operator/pull/745
 
 ## [25.3.0] - 2025-03-21
 

--- a/tests/templates/kuttl/opa-authorization/10-install-opa.yaml.j2
+++ b/tests/templates/kuttl/opa-authorization/10-install-opa.yaml.j2
@@ -11,7 +11,12 @@ commands:
         name: opa
       spec:
         image:
+{% if test_scenario['values']['opa'].find(",") > 0 %}
+          custom: "{{ test_scenario['values']['opa'].split(',')[1] }}"
+          productVersion: "{{ test_scenario['values']['opa'].split(',')[0] }}"
+{% else %}
           productVersion: "{{ test_scenario['values']['opa'] }}"
+{% endif %}
           pullPolicy: IfNotPresent
         clusterConfig:
           userInfo:

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -38,7 +38,7 @@ dimensions:
       - 4.0.1
   - name: opa
     values:
-      - 1.0.1
+      - 1.4.2
   - name: hdfs
     values:
       - 3.4.1


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1084.

- Bump OPA to 1.4.2 in tests.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
