### PR TITLE
tests: increase OPA assert timeouts

### DIFF
--- a/tests/templates/kuttl/opa-authorization/10-assert.yaml
+++ b/tests/templates/kuttl/opa-authorization/10-assert.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 300
+timeout: 600
 commands:
-  - script: kubectl -n $NAMESPACE rollout status daemonset opa-server-default --timeout 300s
+  - script: kubectl -n $NAMESPACE rollout status daemonset opa-server-default --timeout 600s

--- a/tests/templates/kuttl/smoke/09-assert.yaml
+++ b/tests/templates/kuttl/smoke/09-assert.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 300
+timeout: 600
 commands:
-  - script: kubectl -n $NAMESPACE rollout status daemonset opa-server-default --timeout 300s
+  - script: kubectl -n $NAMESPACE rollout status daemonset opa-server-default --timeout 600s

--- a/tests/templates/kuttl/smoke_aws/09-assert.yaml
+++ b/tests/templates/kuttl/smoke_aws/09-assert.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 300
+timeout: 600
 commands:
-  - script: kubectl -n $NAMESPACE rollout status daemonset opa-server-default --timeout 300s
+  - script: kubectl -n $NAMESPACE rollout status daemonset opa-server-default --timeout 600s


### PR DESCRIPTION
## Description

Latest weekly tests fail while waiting for the OPA Daemonsets to become ready.

For example: https://testing.stackable.tech/job/trino-operator-it-weekly/58/artifact/target/test-output.log/*view*/

It is worth knowing that the weekly tests require 10 nodes to run and this obviously puts a strain on `oci.stackable.tech`.




## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
