### PR TITLE
Listener: Use headless and metrics service

### DIFF
--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -36,8 +36,7 @@ use stackable_operator::{
             apps::v1::{StatefulSet, StatefulSetSpec},
             core::v1::{
                 ConfigMap, ConfigMapVolumeSource, ContainerPort, EnvVar, EnvVarSource, ExecAction,
-                HTTPGetAction, Probe, Secret, SecretKeySelector, Service, ServicePort, ServiceSpec,
-                Volume,
+                HTTPGetAction, Probe, Secret, SecretKeySelector, Volume,
             },
         },
         apimachinery::pkg::{apis::meta::v1::LabelSelector, util::intstr::IntOrString},
@@ -47,7 +46,7 @@ use stackable_operator::{
         core::{DeserializeGuard, error_boundary},
         runtime::{controller::Action, reflector::ObjectRef},
     },
-    kvp::{Annotation, Label, Labels, ObjectLabels},
+    kvp::{Annotation, Labels, ObjectLabels},
     logging::controller::ReconcilerError,
     memory::{BinaryMultiple, MemoryQuantity},
     product_config_utils::{
@@ -98,6 +97,7 @@ use crate::{
         add_graceful_shutdown_config, graceful_shutdown_config_properties, pdb::add_pdbs,
     },
     product_logging::{get_log_properties, get_vector_toml},
+    service::{build_rolegroup_headless_service, build_rolegroup_metrics_service},
 };
 
 pub struct Ctx {
@@ -357,6 +357,9 @@ pub enum Error {
 
     #[snafu(display("failed to configure listener"))]
     ListenerConfiguration { source: crate::listener::Error },
+
+    #[snafu(display("failed to configure service"))]
+    ServiceConfiguration { source: crate::service::Error },
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
@@ -482,8 +485,36 @@ pub async fn reconcile_trino(
                 .merged_config(&trino_role, &role_group_ref, &catalog_definitions)
                 .context(FailedToResolveConfigSnafu)?;
 
-            let rg_service =
-                build_rolegroup_service(trino, &resolved_product_image, &role_group_ref)?;
+            let role_group_service_recommended_labels = build_recommended_labels(
+                trino,
+                &resolved_product_image.app_version_label,
+                &role_group_ref.role,
+                &role_group_ref.role_group,
+            );
+
+            let role_group_service_selector = Labels::role_group_selector(
+                trino,
+                APP_NAME,
+                &role_group_ref.role,
+                &role_group_ref.role_group,
+            )
+            .context(LabelBuildSnafu)?;
+
+            let rg_headless_service = build_rolegroup_headless_service(
+                trino,
+                &role_group_ref,
+                role_group_service_recommended_labels.clone(),
+                role_group_service_selector.clone().into(),
+            )
+            .context(ServiceConfigurationSnafu)?;
+            let rg_metrics_service = build_rolegroup_metrics_service(
+                trino,
+                &role_group_ref,
+                role_group_service_recommended_labels,
+                role_group_service_selector.into(),
+            )
+            .context(ServiceConfigurationSnafu)?;
+
             let rg_configmap = build_rolegroup_config_map(
                 trino,
                 &resolved_product_image,
@@ -515,7 +546,13 @@ pub async fn reconcile_trino(
             )?;
 
             cluster_resources
-                .add(client, rg_service)
+                .add(client, rg_headless_service)
+                .await
+                .with_context(|_| ApplyRoleGroupServiceSnafu {
+                    rolegroup: role_group_ref.clone(),
+                })?;
+            cluster_resources
+                .add(client, rg_metrics_service)
                 .await
                 .with_context(|_| ApplyRoleGroupServiceSnafu {
                     rolegroup: role_group_ref.clone(),
@@ -1204,53 +1241,6 @@ fn build_rolegroup_statefulset(
     })
 }
 
-/// The rolegroup [`Service`] is a headless service that allows direct access to the instances of a certain rolegroup
-///
-/// This is mostly useful for internal communication between peers, or for clients that perform client-side load balancing.
-fn build_rolegroup_service(
-    trino: &v1alpha1::TrinoCluster,
-    resolved_product_image: &ResolvedProductImage,
-    role_group_ref: &RoleGroupRef<v1alpha1::TrinoCluster>,
-) -> Result<Service> {
-    Ok(Service {
-        metadata: ObjectMetaBuilder::new()
-            .name_and_namespace(trino)
-            .name(rolegroup_metrics_service_name(
-                &role_group_ref.object_name(),
-            ))
-            .ownerreference_from_resource(trino, None, Some(true))
-            .context(ObjectMissingMetadataForOwnerRefSnafu)?
-            .with_recommended_labels(build_recommended_labels(
-                trino,
-                &resolved_product_image.app_version_label,
-                &role_group_ref.role,
-                &role_group_ref.role_group,
-            ))
-            .context(MetadataBuildSnafu)?
-            .with_label(Label::try_from(("prometheus.io/scrape", "true")).context(LabelBuildSnafu)?)
-            .build(),
-        spec: Some(ServiceSpec {
-            // Internal communication does not need to be exposed
-            type_: Some("ClusterIP".to_string()),
-            cluster_ip: Some("None".to_string()),
-            ports: Some(service_ports()),
-            selector: Some(
-                Labels::role_group_selector(
-                    trino,
-                    APP_NAME,
-                    &role_group_ref.role,
-                    &role_group_ref.role_group,
-                )
-                .context(LabelBuildSnafu)?
-                .into(),
-            ),
-            publish_not_ready_addresses: Some(true),
-            ..ServiceSpec::default()
-        }),
-        status: None,
-    })
-}
-
 pub fn error_policy(
     _obj: Arc<DeserializeGuard<v1alpha1::TrinoCluster>>,
     error: &Error,
@@ -1407,15 +1397,6 @@ fn get_random_base64() -> String {
     let mut buf = [0; 512];
     openssl::rand::rand_bytes(&mut buf).unwrap();
     openssl::base64::encode_block(&buf)
-}
-
-fn service_ports() -> Vec<ServicePort> {
-    vec![ServicePort {
-        name: Some(METRICS_PORT_NAME.to_string()),
-        port: METRICS_PORT.into(),
-        protocol: Some("TCP".to_string()),
-        ..ServicePort::default()
-    }]
 }
 
 fn container_ports(trino: &v1alpha1::TrinoCluster) -> Vec<ContainerPort> {

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -119,6 +119,7 @@ pub const MAX_TRINO_LOG_FILES_SIZE: MemoryQuantity = MemoryQuantity {
 };
 
 pub const METRICS_SERVICE_SUFFIX: &str = "metrics";
+pub const HEADLESS_SERVICE_SUFFIX: &str = "headless";
 
 pub const JVM_HEAP_FACTOR: f32 = 0.8;
 
@@ -943,6 +944,11 @@ impl v1alpha1::TrinoCluster {
 /// Returns the metrics rolegroup service name `<cluster>-<role>-<rolegroup>-<METRICS_SERVICE_SUFFIX>`.
 pub fn rolegroup_metrics_service_name(role_group_ref_object_name: &str) -> String {
     format!("{role_group_ref_object_name}-{METRICS_SERVICE_SUFFIX}")
+}
+
+/// Returns the headless rolegroup service name `<cluster>-<role>-<rolegroup>-<HEADLESS_SERVICE_SUFFIX>`.
+pub fn rolegroup_headless_service_name(role_group_ref_object_name: &str) -> String {
+    format!("{role_group_ref_object_name}-{HEADLESS_SERVICE_SUFFIX}")
 }
 
 fn extract_role_from_coordinator_config(

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -8,6 +8,7 @@ mod crd;
 mod listener;
 mod operations;
 mod product_logging;
+mod service;
 
 use std::sync::Arc;
 

--- a/rust/operator-binary/src/service.rs
+++ b/rust/operator-binary/src/service.rs
@@ -1,0 +1,117 @@
+use std::collections::BTreeMap;
+
+use snafu::{ResultExt, Snafu};
+use stackable_operator::{
+    builder::meta::ObjectMetaBuilder,
+    k8s_openapi::api::core::v1::{Service, ServicePort, ServiceSpec},
+    kvp::{Label, ObjectLabels},
+    role_utils::RoleGroupRef,
+};
+
+use crate::crd::{
+    METRICS_PORT, METRICS_PORT_NAME, rolegroup_headless_service_name,
+    rolegroup_metrics_service_name, v1alpha1,
+};
+
+#[derive(Snafu, Debug)]
+pub enum Error {
+    #[snafu(display("object is missing metadata to build owner reference"))]
+    ObjectMissingMetadataForOwnerRef {
+        source: stackable_operator::builder::meta::Error,
+    },
+
+    #[snafu(display("failed to build Metadata"))]
+    MetadataBuild {
+        source: stackable_operator::builder::meta::Error,
+    },
+
+    #[snafu(display("failed to build Labels"))]
+    LabelBuild {
+        source: stackable_operator::kvp::LabelError,
+    },
+}
+
+/// The rolegroup headless [`Service`] is a service that allows direct access to the instances of a certain rolegroup
+/// This is mostly useful for internal communication between peers, or for clients that perform client-side load balancing.
+pub fn build_rolegroup_headless_service(
+    trino: &v1alpha1::TrinoCluster,
+    role_group_ref: &RoleGroupRef<v1alpha1::TrinoCluster>,
+    object_labels: ObjectLabels<v1alpha1::TrinoCluster>,
+    selector: BTreeMap<String, String>,
+) -> Result<Service, Error> {
+    Ok(Service {
+        metadata: ObjectMetaBuilder::new()
+            .name_and_namespace(trino)
+            .name(rolegroup_headless_service_name(
+                &role_group_ref.object_name(),
+            ))
+            .ownerreference_from_resource(trino, None, Some(true))
+            .context(ObjectMissingMetadataForOwnerRefSnafu)?
+            .with_recommended_labels(object_labels)
+            .context(MetadataBuildSnafu)?
+            .build(),
+        spec: Some(ServiceSpec {
+            // Internal communication does not need to be exposed
+            type_: Some("ClusterIP".to_string()),
+            cluster_ip: Some("None".to_string()),
+            ports: Some(headless_service_ports(trino)),
+            selector: Some(selector),
+            publish_not_ready_addresses: Some(true),
+            ..ServiceSpec::default()
+        }),
+        status: None,
+    })
+}
+
+/// The rolegroup metrics [`Service`] is a service that exposes metrics and a prometheus scraping label.
+pub fn build_rolegroup_metrics_service(
+    trino: &v1alpha1::TrinoCluster,
+    role_group_ref: &RoleGroupRef<v1alpha1::TrinoCluster>,
+    object_labels: ObjectLabels<v1alpha1::TrinoCluster>,
+    selector: BTreeMap<String, String>,
+) -> Result<Service, Error> {
+    Ok(Service {
+        metadata: ObjectMetaBuilder::new()
+            .name_and_namespace(trino)
+            .name(rolegroup_metrics_service_name(
+                &role_group_ref.object_name(),
+            ))
+            .ownerreference_from_resource(trino, None, Some(true))
+            .context(ObjectMissingMetadataForOwnerRefSnafu)?
+            .with_recommended_labels(object_labels)
+            .context(MetadataBuildSnafu)?
+            .with_label(Label::try_from(("prometheus.io/scrape", "true")).context(LabelBuildSnafu)?)
+            .build(),
+        spec: Some(ServiceSpec {
+            // Internal communication does not need to be exposed
+            type_: Some("ClusterIP".to_string()),
+            cluster_ip: Some("None".to_string()),
+            ports: Some(metrics_service_ports()),
+            selector: Some(selector),
+            publish_not_ready_addresses: Some(true),
+            ..ServiceSpec::default()
+        }),
+        status: None,
+    })
+}
+
+fn headless_service_ports(trino: &v1alpha1::TrinoCluster) -> Vec<ServicePort> {
+    let name = trino.exposed_protocol().to_string();
+    let port = trino.exposed_port().into();
+
+    vec![ServicePort {
+        name: Some(name),
+        port,
+        protocol: Some("TCP".to_string()),
+        ..ServicePort::default()
+    }]
+}
+
+fn metrics_service_ports() -> Vec<ServicePort> {
+    vec![ServicePort {
+        name: Some(METRICS_PORT_NAME.to_string()),
+        port: METRICS_PORT.into(),
+        protocol: Some("TCP".to_string()),
+        ..ServicePort::default()
+    }]
+}

--- a/tests/templates/kuttl/listener/10-assert.yaml
+++ b/tests/templates/kuttl/listener/10-assert.yaml
@@ -47,9 +47,23 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: test-trino-coordinator-default-headless
+spec:
+  type: ClusterIP # cluster-internal - by trino op
+---
+apiVersion: v1
+kind: Service
+metadata:
   name: test-trino-coordinator-default-metrics
 spec:
   type: ClusterIP # cluster-internal - by trino op
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-trino-worker-default-headless
+spec:
+  type: ClusterIP # cluster-internal - by trino op  
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Description

This splits the previous `metrics` internal service into a metrics service with the prometheus scrape label and a headless service for internal communication.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
