### PR TITLE
test: Improve the performance of the OPA rego rules

### DIFF
--- a/tests/templates/kuttl/opa-authorization/trino_rules/requested_permissions.rego
+++ b/tests/templates/kuttl/opa-authorization/trino_rules/requested_permissions.rego
@@ -8,12 +8,8 @@ package trino
 # for the file-based access control
 # (https://trino.io/docs/current/security/file-system-access-control.html).
 
-action := input.action
-
-operation := action.operation
-
-requested_permissions := permissions if {
-	operation == "AccessCatalog"
+requested_permissions(action) := permissions if {
+	action.operation == "AccessCatalog"
 	permissions := {{
 		"resource": "catalog",
 		"catalogName": action.resource.catalog.name,
@@ -21,8 +17,8 @@ requested_permissions := permissions if {
 	}}
 }
 
-requested_permissions := permissions if {
-	operation in {
+requested_permissions(action) := permissions if {
+	action.operation in {
 		"CreateSchema",
 		"DropSchema",
 		"ShowCreateSchema",
@@ -42,8 +38,8 @@ requested_permissions := permissions if {
 	}
 }
 
-requested_permissions := permissions if {
-	operation in {
+requested_permissions(action) := permissions if {
+	action.operation in {
 		"AddColumn",
 		"AlterColumn",
 		"CreateMaterializedView",
@@ -78,8 +74,8 @@ requested_permissions := permissions if {
 	}
 }
 
-requested_permissions := permissions if {
-	operation in {
+requested_permissions(action) := permissions if {
+	action.operation in {
 		"RefreshMaterializedView",
 		"UpdateTableColumns",
 	}
@@ -99,8 +95,8 @@ requested_permissions := permissions if {
 	}
 }
 
-requested_permissions := permissions if {
-	operation in {
+requested_permissions(action) := permissions if {
+	action.operation in {
 		"DeleteFromTable",
 		"TruncateTable",
 	}
@@ -120,23 +116,23 @@ requested_permissions := permissions if {
 	}
 }
 
-requested_permissions := permissions if {
-	operation == "ExecuteQuery"
+requested_permissions(action) := permissions if {
+	action.operation == "ExecuteQuery"
 	permissions := {{
 		"resource": "query",
 		"allow": {"execute"},
 	}}
 }
 
-requested_permissions := permissions if {
-	operation == "ExecuteTableProcedure"
+requested_permissions(action) := permissions if {
+	action.operation == "ExecuteTableProcedure"
 
 	# Executing table procedures is always allowed
 	permissions := set()
 }
 
-requested_permissions := permissions if {
-	operation == "FilterColumns"
+requested_permissions(action) := permissions if {
+	action.operation == "FilterColumns"
 	permissions := {
 		{
 			"resource": "table",
@@ -163,8 +159,8 @@ requested_permissions := permissions if {
 	}
 }
 
-requested_permissions := permissions if {
-	operation == "KillQueryOwnedBy"
+requested_permissions(action) := permissions if {
+	action.operation == "KillQueryOwnedBy"
 	permissions := {{
 		"resource": "query_owned_by",
 		"user": action.resource.user.user,
@@ -173,8 +169,8 @@ requested_permissions := permissions if {
 	}}
 }
 
-requested_permissions := permissions if {
-	operation in {
+requested_permissions(action) := permissions if {
+	action.operation in {
 		"FilterViewQueryOwnedBy",
 		"ViewQueryOwnedBy",
 	}
@@ -186,8 +182,8 @@ requested_permissions := permissions if {
 	}}
 }
 
-requested_permissions := permissions if {
-	operation == "FilterTables"
+requested_permissions(action) := permissions if {
+	action.operation == "FilterTables"
 	permissions := {
 		{
 			"resource": "catalog",
@@ -211,8 +207,8 @@ requested_permissions := permissions if {
 	}
 }
 
-requested_permissions := permissions if {
-	operation in {
+requested_permissions(action) := permissions if {
+	action.operation in {
 		"CreateFunction",
 		"DropFunction",
 	}
@@ -232,8 +228,8 @@ requested_permissions := permissions if {
 	}
 }
 
-requested_permissions := permissions if {
-	operation in {
+requested_permissions(action) := permissions if {
+	action.operation in {
 		"ExecuteFunction",
 		"FilterFunctions",
 	}
@@ -253,8 +249,8 @@ requested_permissions := permissions if {
 	}
 }
 
-requested_permissions := permissions if {
-	operation == "ExecuteProcedure"
+requested_permissions(action) := permissions if {
+	action.operation == "ExecuteProcedure"
 	permissions := {
 		{
 			"resource": "catalog",
@@ -271,8 +267,8 @@ requested_permissions := permissions if {
 	}
 }
 
-requested_permissions := permissions if {
-	operation == "CreateViewWithExecuteFunction"
+requested_permissions(action) := permissions if {
+	action.operation == "CreateViewWithExecuteFunction"
 	permissions := {
 		{
 			"resource": "catalog",
@@ -289,8 +285,8 @@ requested_permissions := permissions if {
 	}
 }
 
-requested_permissions := permissions if {
-	operation == "ImpersonateUser"
+requested_permissions(action) := permissions if {
+	action.operation == "ImpersonateUser"
 	permissions := {{
 		"resource": "impersonation",
 		"user": action.resource.user.user,
@@ -298,8 +294,8 @@ requested_permissions := permissions if {
 	}}
 }
 
-requested_permissions := permissions if {
-	operation == "InsertIntoTable"
+requested_permissions(action) := permissions if {
+	action.operation == "InsertIntoTable"
 	permissions := {
 		{
 			"resource": "catalog",
@@ -316,16 +312,16 @@ requested_permissions := permissions if {
 	}
 }
 
-requested_permissions := permissions if {
-	operation == "ReadSystemInformation"
+requested_permissions(action) := permissions if {
+	action.operation == "ReadSystemInformation"
 	permissions := {{
 		"resource": "system_information",
 		"allow": {"read"},
 	}}
 }
 
-requested_permissions := permissions if {
-	operation == "RenameSchema"
+requested_permissions(action) := permissions if {
+	action.operation == "RenameSchema"
 	permissions := {
 		{
 			"resource": "catalog",
@@ -352,8 +348,8 @@ requested_permissions := permissions if {
 	}
 }
 
-requested_permissions := permissions if {
-	operation in {
+requested_permissions(action) := permissions if {
+	action.operation in {
 		"RenameMaterializedView",
 		"RenameTable",
 		"RenameView",
@@ -386,8 +382,8 @@ requested_permissions := permissions if {
 	}
 }
 
-requested_permissions := permissions if {
-	operation == "SelectFromColumns"
+requested_permissions(action) := permissions if {
+	action.operation == "SelectFromColumns"
 	column_permissions := {
 	{
 		"resource": "column",
@@ -415,8 +411,8 @@ requested_permissions := permissions if {
 	} | column_permissions
 }
 
-requested_permissions := permissions if {
-	operation == "SetSchemaAuthorization"
+requested_permissions(action) := permissions if {
+	action.operation == "SetSchemaAuthorization"
 	permissions := {
 		{
 			"resource": "catalog",
@@ -438,8 +434,8 @@ requested_permissions := permissions if {
 	}
 }
 
-requested_permissions := permissions if {
-	operation in {
+requested_permissions(action) := permissions if {
+	action.operation in {
 		"SetTableAuthorization",
 		"SetViewAuthorization",
 	}
@@ -465,8 +461,8 @@ requested_permissions := permissions if {
 	}
 }
 
-requested_permissions := permissions if {
-	operation == "ShowColumns"
+requested_permissions(action) := permissions if {
+	action.operation == "ShowColumns"
 	permissions := {
 		{
 			"resource": "catalog",
@@ -490,8 +486,8 @@ requested_permissions := permissions if {
 	}
 }
 
-requested_permissions := permissions if {
-	operation in {
+requested_permissions(action) := permissions if {
+	action.operation in {
 		"FilterCatalogs",
 		"ShowSchemas",
 	}
@@ -508,8 +504,8 @@ requested_permissions := permissions if {
 	}
 }
 
-requested_permissions := permissions if {
-	operation in {
+requested_permissions(action) := permissions if {
+	action.operation in {
 		"FilterSchemas",
 		"ShowFunctions",
 		"ShowTables",
@@ -528,8 +524,8 @@ requested_permissions := permissions if {
 	}
 }
 
-requested_permissions := permissions if {
-	operation == "SetCatalogSessionProperty"
+requested_permissions(action) := permissions if {
+	action.operation == "SetCatalogSessionProperty"
 	permissions := {
 		{
 			"resource": "catalog",
@@ -545,8 +541,8 @@ requested_permissions := permissions if {
 	}
 }
 
-requested_permissions := permissions if {
-	operation == "SetSystemSessionProperty"
+requested_permissions(action) := permissions if {
+	action.operation == "SetSystemSessionProperty"
 	permissions := {{
 		"resource": "system_session_properties",
 		"propertyName": action.resource.systemSessionProperty.name,
@@ -554,91 +550,91 @@ requested_permissions := permissions if {
 	}}
 }
 
-requested_permissions := permissions if {
-	operation == "WriteSystemInformation"
+requested_permissions(action) := permissions if {
+	action.operation == "WriteSystemInformation"
 	permissions := {{
 		"resource": "system_information",
 		"allow": {"write"},
 	}}
 }
 
-requested_authorization_permissions contains permission if {
-	some permission in requested_permissions
+requested_authorization_permissions(action) := [permission |
+	some permission in requested_permissions(action)
 	permission.resource == "authorization"
-}
+]
 
-requested_catalog_permissions contains permission if {
-	some permission in requested_permissions
+requested_catalog_permissions(action) := [permission |
+	some permission in requested_permissions(action)
 	permission.resource == "catalog"
-}
+]
 
-requested_catalog_session_properties_permissions contains permission if {
-	some permission in requested_permissions
+requested_catalog_session_properties_permissions(action) := [permission |
+	some permission in requested_permissions(action)
 	permission.resource == "catalog_session_properties"
-}
+]
 
-requested_catalog_visibility_permissions contains permission if {
-	some permission in requested_permissions
+requested_catalog_visibility_permissions(action) := [permission |
+	some permission in requested_permissions(action)
 	permission.resource == "catalog_visibility"
-}
+]
 
-requested_column_permissions contains permission if {
-	some permission in requested_permissions
+requested_column_permissions(action) := [permission |
+	some permission in requested_permissions(action)
 	permission.resource == "column"
-}
+]
 
-requested_function_permissions contains permission if {
-	some permission in requested_permissions
+requested_function_permissions(action) := [permission |
+	some permission in requested_permissions(action)
 	permission.resource == "function"
-}
+]
 
-requested_impersonation_permissions contains permission if {
-	some permission in requested_permissions
+requested_impersonation_permissions(action) := [permission |
+	some permission in requested_permissions(action)
 	permission.resource == "impersonation"
-}
+]
 
-requested_procedure_permissions contains permission if {
-	some permission in requested_permissions
+requested_procedure_permissions(action) := [permission |
+	some permission in requested_permissions(action)
 	permission.resource == "procedure"
-}
+]
 
-requested_query_permissions contains permission if {
-	some permission in requested_permissions
+requested_query_permissions(action) := [permission |
+	some permission in requested_permissions(action)
 	permission.resource == "query"
-}
+]
 
-requested_query_owned_by_permissions contains permission if {
-	some permission in requested_permissions
+requested_query_owned_by_permissions(action) := [permission |
+	some permission in requested_permissions(action)
 	permission.resource == "query_owned_by"
-}
+]
 
-requested_schema_permissions contains permission if {
-	some permission in requested_permissions
+requested_schema_permissions(action) := [permission |
+	some permission in requested_permissions(action)
 	permission.resource == "schema"
-}
+]
 
-requested_schema_visibility_permissions contains permission if {
-	some permission in requested_permissions
+requested_schema_visibility_permissions(action) := [permission |
+	some permission in requested_permissions(action)
 	permission.resource == "schema_visibility"
-}
+]
 
-requested_table_permissions contains permission if {
-	some permission in requested_permissions
+requested_table_permissions(action) := [permission |
+	some permission in requested_permissions(action)
 	permission.resource == "table"
-}
+]
 
-requested_system_information_permissions contains permission if {
-	some permission in requested_permissions
+requested_system_information_permissions(action) := [permission |
+	some permission in requested_permissions(action)
 	permission.resource == "system_information"
-}
+]
 
-requested_system_session_properties_permissions contains permission if {
-	some permission in requested_permissions
+requested_system_session_properties_permissions(action) := [permission |
+	some permission in requested_permissions(action)
 	permission.resource == "system_session_properties"
-}
+]
 
-requested_column_mask := request if {
-	operation == "GetColumnMask"
+requested_column_mask(action) := request if {
+	action.operation == "GetColumnMask"
 	request := {
 		"catalogName": action.resource.column.catalogName,
 		"schemaName": action.resource.column.schemaName,
@@ -647,8 +643,8 @@ requested_column_mask := request if {
 	}
 }
 
-requested_row_filters := request if {
-	operation == "GetRowFilters"
+requested_row_filters(action) := request if {
+	action.operation == "GetRowFilters"
 	request := {
 		"catalogName": action.resource.table.catalogName,
 		"schemaName": action.resource.table.schemaName,

--- a/tests/templates/kuttl/opa-authorization/trino_rules/requested_permissions_test.rego
+++ b/tests/templates/kuttl/opa-authorization/trino_rules/requested_permissions_test.rego
@@ -279,61 +279,44 @@ permission_valid(permission) if {
 	)
 }
 
-testcontext := {
-	"identity": {
-		"groups": ["testgroup1", "testgroup2"],
-		"user": "testuser",
-	},
-	"softwareStack": {"trinoVersion": "455"},
-}
-
 test_access_filter_catalog if {
 	operations := {
 		"AccessCatalog",
 		"FilterCatalogs",
 	}
 	every operation in operations {
-		permissions := trino.requested_permissions with input as {
-			"action": {
-				"operation": operation,
-				"resource": {"catalog": {"name": "testcatalog"}},
-			},
-			"context": testcontext,
-		}
+		permissions := trino.requested_permissions({
+			"operation": operation,
+			"resource": {"catalog": {"name": "testcatalog"}},
+		})
 
 		permissions_valid(permissions)
 	}
 }
 
 test_create_schema if {
-	permissions := trino.requested_permissions with input as {
-		"action": {
-			"operation": "CreateSchema",
-			"resource": {"schema": {
-				"catalogName": "testcatalog",
-				"schemaName": "testschema",
-				"properties": {},
-			}},
-		},
-		"context": testcontext,
-	}
+	permissions := trino.requested_permissions({
+		"operation": "CreateSchema",
+		"resource": {"schema": {
+			"catalogName": "testcatalog",
+			"schemaName": "testschema",
+			"properties": {},
+		}},
+	})
 
 	permissions_valid(permissions)
 }
 
 test_filter_columns if {
-	permissions := trino.requested_permissions with input as {
-		"action": {
-			"operation": "FilterColumns",
-			"resource": {"table": {
-				"catalogName": "testcatalog",
-				"schemaName": "testschema",
-				"tableName": "testtable",
-				"columnName": "testcolumn",
-			}},
-		},
-		"context": testcontext,
-	}
+	permissions := trino.requested_permissions({
+		"operation": "FilterColumns",
+		"resource": {"table": {
+			"catalogName": "testcatalog",
+			"schemaName": "testschema",
+			"tableName": "testtable",
+			"columnName": "testcolumn",
+		}},
+	})
 
 	permissions_valid(permissions)
 }
@@ -348,17 +331,14 @@ test_function_resource_actions if {
 		"FilterFunctions",
 	}
 	every operation in operations {
-		permissions := trino.requested_permissions with input as {
-			"action": {
-				"operation": operation,
-				"resource": {"function": {
-					"catalogName": "testcatalog",
-					"schemaName": "testschema",
-					"functionName": "testfunction",
-				}},
-			},
-			"context": testcontext,
-		}
+		permissions := trino.requested_permissions({
+			"operation": operation,
+			"resource": {"function": {
+				"catalogName": "testcatalog",
+				"schemaName": "testschema",
+				"functionName": "testfunction",
+			}},
+		})
 
 		permissions_valid(permissions)
 	}
@@ -371,30 +351,24 @@ test_no_resource_action if {
 		"WriteSystemInformation",
 	}
 	every operation in operations {
-		permissions := trino.requested_permissions with input as {
-			"action": {"operation": operation},
-			"context": testcontext,
-		}
+		permissions := trino.requested_permissions({"operation": operation})
 
 		permissions_valid(permissions)
 	}
 }
 
 test_execute_table_procedure if {
-	permissions := trino.requested_permissions with input as {
-		"action": {
-			"operation": "ExecuteTableProcedure",
-			"resource": {
-				"table": {
-					"catalogName": "testcatalog",
-					"schemaName": "testschema",
-					"tableName": "testtable",
-				},
-				"function": {"functionName": "testprocedure"},
+	permissions := trino.requested_permissions({
+		"operation": "ExecuteTableProcedure",
+		"resource": {
+			"table": {
+				"catalogName": "testcatalog",
+				"schemaName": "testschema",
+				"tableName": "testtable",
 			},
+			"function": {"functionName": "testprocedure"},
 		},
-		"context": testcontext,
-	}
+	})
 
 	permissions_valid(permissions)
 }
@@ -406,31 +380,25 @@ test_column_operations_on_table_like_objects if {
 		"UpdateTableColumns",
 	}
 	every operation in operations {
-		permissions := trino.requested_permissions with input as {
-			"action": {
-				"operation": operation,
-				"resource": {"table": {
-					"catalogName": "testcatalog",
-					"schemaName": "testschema",
-					"tableName": "testtable",
-					"columns": ["testcolumn1", "testcolumn2"],
-				}},
-			},
-			"context": testcontext,
-		}
+		permissions := trino.requested_permissions({
+			"operation": operation,
+			"resource": {"table": {
+				"catalogName": "testcatalog",
+				"schemaName": "testschema",
+				"tableName": "testtable",
+				"columns": ["testcolumn1", "testcolumn2"],
+			}},
+		})
 
 		permissions_valid(permissions)
 	}
 }
 
 test_show_schemas if {
-	permissions := trino.requested_permissions with input as {
-		"action": {
-			"operation": "ShowSchemas",
-			"resource": {"catalog": {"name": "testcatalog"}},
-		},
-		"context": testcontext,
-	}
+	permissions := trino.requested_permissions({
+		"operation": "ShowSchemas",
+		"resource": {"catalog": {"name": "testcatalog"}},
+	})
 
 	permissions_valid(permissions)
 }
@@ -457,17 +425,14 @@ test_table_resource_actions if {
 		"TruncateTable",
 	}
 	every operation in operations {
-		permissions := trino.requested_permissions with input as {
-			"action": {
-				"operation": operation,
-				"resource": {"table": {
-					"catalogName": "testcatalog",
-					"schemaName": "testschema",
-					"tableName": "testtable",
-				}},
-			},
-			"context": testcontext,
-		}
+		permissions := trino.requested_permissions({
+			"operation": operation,
+			"resource": {"table": {
+				"catalogName": "testcatalog",
+				"schemaName": "testschema",
+				"tableName": "testtable",
+			}},
+		})
 
 		permissions_valid(permissions)
 	}
@@ -481,22 +446,19 @@ test_table_with_properties_actions if {
 		"SetTableProperties",
 	}
 	every operation in operations {
-		permissions := trino.requested_permissions with input as {
-			"action": {
-				"operation": operation,
-				"resource": {"table": {
-					"catalogName": "testcatalog",
-					"schemaName": "testschema",
-					"tableName": "testtable",
-					"properties": {
-						"string_item": "string_value",
-						"empty_item": null,
-						"boxed_number_item": 32,
-					},
-				}},
-			},
-			"context": testcontext,
-		}
+		permissions := trino.requested_permissions({
+			"operation": operation,
+			"resource": {"table": {
+				"catalogName": "testcatalog",
+				"schemaName": "testschema",
+				"tableName": "testtable",
+				"properties": {
+					"string_item": "string_value",
+					"empty_item": null,
+					"boxed_number_item": 32,
+				},
+			}},
+		})
 
 		permissions_valid(permissions)
 	}
@@ -509,16 +471,13 @@ test_identity_resource_actions if {
 		"ViewQueryOwnedBy",
 	}
 	every operation in operations {
-		permissions := trino.requested_permissions with input as {
-			"action": {
-				"operation": operation,
-				"resource": {"user": {
-					"user": "testuser",
-					"groups": ["testgroup1", "testgroup2"],
-				}},
-			},
-			"context": testcontext,
-		}
+		permissions := trino.requested_permissions({
+			"operation": operation,
+			"resource": {"user": {
+				"user": "testuser",
+				"groups": ["testgroup1", "testgroup2"],
+			}},
+		})
 
 		permissions_valid(permissions)
 	}
@@ -533,16 +492,13 @@ test_schema_resource_actions if {
 		"ShowTables",
 	}
 	every operation in operations {
-		permissions := trino.requested_permissions with input as {
-			"action": {
-				"operation": operation,
-				"resource": {"schema": {
-					"catalogName": "testcatalog",
-					"schemaName": "testschema",
-				}},
-			},
-			"context": testcontext,
-		}
+		permissions := trino.requested_permissions({
+			"operation": operation,
+			"resource": {"schema": {
+				"catalogName": "testcatalog",
+				"schemaName": "testschema",
+			}},
+		})
 
 		permissions_valid(permissions)
 	}
@@ -555,88 +511,73 @@ test_rename_table_like_object if {
 		"RenameView",
 	}
 	every operation in operations {
-		permissions := trino.requested_permissions with input as {
-			"action": {
-				"operation": operation,
-				"resource": {"table": {
-					"catalogName": "testcatalog",
-					"schemaName": "testschema",
-					"tableName": "testtable",
-				}},
-				"targetResource": {"table": {
-					"catalogName": "testcatalog",
-					"schemaName": "testschema",
-					"tableName": "newtesttable",
-				}},
-			},
-			"context": testcontext,
-		}
+		permissions := trino.requested_permissions({
+			"operation": operation,
+			"resource": {"table": {
+				"catalogName": "testcatalog",
+				"schemaName": "testschema",
+				"tableName": "testtable",
+			}},
+			"targetResource": {"table": {
+				"catalogName": "testcatalog",
+				"schemaName": "testschema",
+				"tableName": "newtesttable",
+			}},
+		})
 
 		permissions_valid(permissions)
 	}
 }
 
 test_rename_schema if {
-	permissions := trino.requested_permissions with input as {
-		"action": {
-			"operation": "RenameSchema",
-			"resource": {"schema": {
-				"catalogName": "testcatalog",
-				"schemaName": "testschema",
-			}},
-			"targetResource": {"schema": {
-				"catalogName": "testcatalog",
-				"schemaName": "newtestschema",
-			}},
-		},
-		"context": testcontext,
-	}
+	permissions := trino.requested_permissions({
+		"operation": "RenameSchema",
+		"resource": {"schema": {
+			"catalogName": "testcatalog",
+			"schemaName": "testschema",
+		}},
+		"targetResource": {"schema": {
+			"catalogName": "testcatalog",
+			"schemaName": "newtestschema",
+		}},
+	})
 
 	permissions_valid(permissions)
 }
 
 test_set_catalog_session_properties if {
-	permissions := trino.requested_permissions with input as {
-		"action": {
-			"operation": "SetCatalogSessionProperty",
-			"resource": {"catalogSessionProperty": {
-				"catalogName": "testcatalog",
-				"propertyName": "testproperty",
-			}},
-		},
-		"context": testcontext,
-	}
+	permissions := trino.requested_permissions({
+		"operation": "SetCatalogSessionProperty",
+		"resource": {"catalogSessionProperty": {
+			"catalogName": "testcatalog",
+			"propertyName": "testproperty",
+		}},
+	})
 
 	permissions_valid(permissions)
 }
 
 test_set_system_session_properties if {
-	permissions := trino.requested_permissions with input as {
-		"action": {
-			"operation": "SetSystemSessionProperty",
-			"resource": {"systemSessionProperty": {"name": "testproperty"}},
-		},
-		"context": testcontext,
-	}
+	permissions := trino.requested_permissions({
+		"operation": "SetSystemSessionProperty",
+		"resource": {"systemSessionProperty": {"name": "testproperty"}},
+	})
 
 	permissions_valid(permissions)
 }
 
 test_set_schema_authorization if {
-	permissions := trino.requested_permissions with input as {
-		"action": {
-			"operation": "SetSchemaAuthorization",
-			"resource": {"schema": {
-				"catalogName": "testcatalog",
-				"schemaName": "testschema",
-			}},
-			"grantee": {
-				"name": "testuser",
-				"type": "testusertype",
-			},
+	permissions := trino.requested_permissions({
+		"operation": "SetSchemaAuthorization",
+		"resource": {"schema": {
+			"catalogName": "testcatalog",
+			"schemaName": "testschema",
+		}},
+		"grantee": {
+			"name": "testuser",
+			"type": "testusertype",
 		},
-		"context": testcontext,
-	}
+	})
 
 	permissions_valid(permissions)
 }
@@ -647,51 +588,42 @@ test_set_authorization_on_table_like_object if {
 		"SetViewAuthorization",
 	}
 	every operation in operations {
-		permissions := trino.requested_permissions with input as {
-			"action": {
-				"operation": operation,
-				"resource": {"table": {
-					"catalogName": "testcatalog",
-					"schemaName": "testschema",
-					"tableName": "testtable",
-				}},
-				"grantee": {
-					"name": "testuser",
-					"type": "testusertype",
-				},
+		permissions := trino.requested_permissions({
+			"operation": operation,
+			"resource": {"table": {
+				"catalogName": "testcatalog",
+				"schemaName": "testschema",
+				"tableName": "testtable",
+			}},
+			"grantee": {
+				"name": "testuser",
+				"type": "testusertype",
 			},
-			"context": testcontext,
-		}
+		})
 
 		permissions_valid(permissions)
 	}
 }
 
 test_impersonate_user if {
-	permissions := trino.requested_permissions with input as {
-		"action": {
-			"operation": "ImpersonateUser",
-			"resource": {"user": {"user": "testuser"}},
-		},
-		"context": testcontext,
-	}
+	permissions := trino.requested_permissions({
+		"operation": "ImpersonateUser",
+		"resource": {"user": {"user": "testuser"}},
+	})
 
 	permissions_valid(permissions)
 }
 
 test_get_column_mask if {
-	request := trino.requested_column_mask with input as {
-		"action": {
-			"operation": "GetColumnMask",
-			"resource": {"column": {
-				"catalogName": "testcatalog",
-				"schemaName": "testschema",
-				"tableName": "testtable",
-				"columnName": "testcolumn",
-			}},
-		},
-		"context": testcontext,
-	}
+	request := trino.requested_column_mask({
+		"operation": "GetColumnMask",
+		"resource": {"column": {
+			"catalogName": "testcatalog",
+			"schemaName": "testschema",
+			"tableName": "testtable",
+			"columnName": "testcolumn",
+		}},
+	})
 
 	request.catalogName == "testcatalog"
 	request.schemaName == "testschema"
@@ -700,17 +632,14 @@ test_get_column_mask if {
 }
 
 test_get_row_filters if {
-	request := trino.requested_row_filters with input as {
-		"action": {
-			"operation": "GetRowFilters",
-			"resource": {"table": {
-				"catalogName": "testcatalog",
-				"schemaName": "testschema",
-				"tableName": "testtable",
-			}},
-		},
-		"context": testcontext,
-	}
+	request := trino.requested_row_filters({
+		"operation": "GetRowFilters",
+		"resource": {"table": {
+			"catalogName": "testcatalog",
+			"schemaName": "testschema",
+			"tableName": "testtable",
+		}},
+	})
 
 	request.catalogName == "testcatalog"
 	request.schemaName == "testschema"

--- a/tests/templates/kuttl/opa-authorization/trino_rules/util.rego
+++ b/tests/templates/kuttl/opa-authorization/trino_rules/util.rego
@@ -12,6 +12,12 @@ package util
 #   Returns:
 #     result (boolean)
 match_entire(pattern, value) if {
+	pattern == `.*`
+}
+
+match_entire(pattern, value) if {
+	pattern != `.*`
+
 	# Add the anchors ^ and $
 	pattern_with_anchors := concat("", ["^", pattern, "$"])
 

--- a/tests/templates/kuttl/opa-authorization/trino_rules/util_test.rego
+++ b/tests/templates/kuttl/opa-authorization/trino_rules/util_test.rego
@@ -3,6 +3,7 @@ package util_test
 import data.util
 
 test_match_entire if {
+	util.match_entire(`.*`, "a")
 	util.match_entire(`a`, "a")
 	util.match_entire(`^a`, "a")
 	util.match_entire(`a$`, "a")


### PR DESCRIPTION
## Description

Improve the performance of the OPA rego rules

The `with` keyword in the `batch` rules prohibited the memoization of results. It is now replaced with function calls where the altered input action is passed as parameter.

## Definition of Done Checklist

### Author

- [x] Integration tests passed (for non trivial changes)

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
