### PR TITLE
chore: Bump Trino version for 25.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ All notable changes to this project will be documented in this file.
 - Support for fault-tolerant execution ([#779], [#793]).
 - Support for the client spooling protocol ([#793]).
 - Helm: Allow Pod `priorityClassName` to be configured ([#798]).
+- Add support for Trino 477 ([#801]).
+
+### Changed
+
+- Deprecate Trino 451 and 476 ([#801]).
 
 ### Fixed
 
@@ -20,10 +25,15 @@ All notable changes to this project will be documented in this file.
   We now correctly handle multiple certificates for both cases.
   See [this GitHub issue](https://github.com/stackabletech/issues/issues/764) for details
 
+### Removed
+
+- Remove support for Trino 470 ([#801]).
+
 [#779]: https://github.com/stackabletech/trino-operator/pull/779
 [#793]: https://github.com/stackabletech/trino-operator/pull/793
 [#796]: https://github.com/stackabletech/trino-operator/pull/796
 [#798]: https://github.com/stackabletech/trino-operator/pull/798
+[#801]: https://github.com/stackabletech/trino-operator/pull/801
 
 ## [25.7.0] - 2025-07-23
 

--- a/docs/modules/trino/examples/getting_started/code/trino.yaml
+++ b/docs/modules/trino/examples/getting_started/code/trino.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-trino
 spec:
   image:
-    productVersion: "476"
+    productVersion: "477"
   clusterConfig:
     catalogLabelSelector:
       matchLabels:

--- a/docs/modules/trino/examples/getting_started/code/trino.yaml.j2
+++ b/docs/modules/trino/examples/getting_started/code/trino.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   name: simple-trino
 spec:
   image:
-    productVersion: "476"
+    productVersion: "477"
   clusterConfig:
     catalogLabelSelector:
       matchLabels:

--- a/docs/modules/trino/examples/usage-guide/fault-tolerant-execution.yaml
+++ b/docs/modules/trino/examples/usage-guide/fault-tolerant-execution.yaml
@@ -5,7 +5,7 @@ metadata:
   name: trino-fault-tolerant
 spec:
   image:
-    productVersion: "476"
+    productVersion: "477"
   clusterConfig:
     catalogLabelSelector:
       matchLabels:

--- a/docs/modules/trino/examples/usage-guide/trino-insecure.yaml
+++ b/docs/modules/trino/examples/usage-guide/trino-insecure.yaml
@@ -17,7 +17,7 @@ metadata:
   name: simple-trino
 spec:
   image:
-    productVersion: "476"
+    productVersion: "477"
   clusterConfig:
     catalogLabelSelector:
       matchLabels:

--- a/docs/modules/trino/examples/usage-guide/trino-secure-internal-tls.yaml
+++ b/docs/modules/trino/examples/usage-guide/trino-secure-internal-tls.yaml
@@ -17,7 +17,7 @@ metadata:
   name: simple-trino
 spec:
   image:
-    productVersion: "476"
+    productVersion: "477"
   clusterConfig:
     tls:
       internalSecretClass: trino-internal-tls # <1>

--- a/docs/modules/trino/examples/usage-guide/trino-secure-tls-only.yaml
+++ b/docs/modules/trino/examples/usage-guide/trino-secure-tls-only.yaml
@@ -17,7 +17,7 @@ metadata:
   name: simple-trino
 spec:
   image:
-    productVersion: "476"
+    productVersion: "477"
   clusterConfig:
     tls:
       serverSecretClass: trino-tls # <1>

--- a/docs/modules/trino/examples/usage-guide/trino-secure-tls.yaml
+++ b/docs/modules/trino/examples/usage-guide/trino-secure-tls.yaml
@@ -17,7 +17,7 @@ metadata:
   name: simple-trino
 spec:
   image:
-    productVersion: "476"
+    productVersion: "477"
   clusterConfig:
     tls:
       serverSecretClass: trino-tls # <1>

--- a/docs/modules/trino/pages/getting_started/installation.adoc
+++ b/docs/modules/trino/pages/getting_started/installation.adoc
@@ -57,8 +57,7 @@ For these components extra steps are required.
 ** a Stackable xref:secret-operator:index.adoc[Secret Operator] for certificates when deploying for TLS
 ** a Stackable xref:commons-operator:index.adoc[Commons Operator] for certificates when deploying for TLS authentication
 ** (for authorization): a Stackable xref:opa:index.adoc[OPA Operator]
-** the https://repo.stackable.tech/#browse/browse:packages:trino-cli%2Ftrino-cli-476-executable.jar[Trino CLI] to test
-   SQL queries
+** the https://repo.stackable.tech/#browse/browse:packages:trino-cli%2Ftrino-cli-477[Trino CLI] to test SQL queries
 
 === S3 bucket
 

--- a/docs/modules/trino/pages/usage-guide/OpenTelemetry.adoc
+++ b/docs/modules/trino/pages/usage-guide/OpenTelemetry.adoc
@@ -1,6 +1,6 @@
 = OpenTelemetry
 :description: Ship Trino traces and logs to OpenTelemetry
-:trino-docs: https://trino.io/docs/470/admin/opentelemetry.html
+:trino-docs: https://trino.io/docs/477/admin/opentelemetry.html
 
 Trino supports sending OpenTelemetry traces as stated in {trino-docs}[the documentation].
 

--- a/docs/modules/trino/pages/usage-guide/catalogs/index.adoc
+++ b/docs/modules/trino/pages/usage-guide/catalogs/index.adoc
@@ -93,7 +93,7 @@ metadata:
   name: simple-trino
 spec:
   image:
-    productVersion: "476"
+    productVersion: "477"
   clusterConfig:
     catalogLabelSelector:
       matchLabels:

--- a/docs/modules/trino/pages/usage-guide/connect_to_trino.adoc
+++ b/docs/modules/trino/pages/usage-guide/connect_to_trino.adoc
@@ -62,7 +62,7 @@ The `--insecure` flag ignores the server TLS certificate and is required in this
 
 [source,console]
 ----
-$ java -jar ~/Downloads/trino-cli-476-executable.jar --server https://85.215.195.29:8443 --user admin --password --insecure
+$ trino-cli-477 --server https://85.215.195.29:8443 --user admin --password --insecure
 ----
 
 TIP: In case you are using OpenID connect, use `--external-authentication` instead of `--password`.

--- a/docs/modules/trino/partials/supported-versions.adoc
+++ b/docs/modules/trino/partials/supported-versions.adoc
@@ -2,6 +2,6 @@
 // This is a separate file, since it is used by both the direct Trino documentation, and the overarching
 // Stackable Platform documentation.
 
-- 476
-- 470 (deprecated)
-- 451 (LTS)
+- 451 (deprecated)
+- 476 (deprecated)
+- 477 (LTS)

--- a/docs/modules/trino/partials/supported-versions.adoc
+++ b/docs/modules/trino/partials/supported-versions.adoc
@@ -2,6 +2,7 @@
 // This is a separate file, since it is used by both the direct Trino documentation, and the overarching
 // Stackable Platform documentation.
 
-- 451 (deprecated)
-- 476 (deprecated)
+// These versions must be sorted in descending order (highest to lowest).
 - 477 (LTS)
+- 476 (deprecated)
+- 451 (deprecated)

--- a/examples/simple-trino-cluster-authentication-opa-authorization-s3.yaml
+++ b/examples/simple-trino-cluster-authentication-opa-authorization-s3.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-trino
 spec:
   image:
-    productVersion: "476"
+    productVersion: "477"
   clusterConfig:
     authentication:
       - authenticationClass: simple-trino-users

--- a/examples/simple-trino-cluster-hive-ha-s3.yaml
+++ b/examples/simple-trino-cluster-hive-ha-s3.yaml
@@ -9,7 +9,7 @@ metadata:
   name: simple-trino
 spec:
   image:
-    productVersion: "476"
+    productVersion: "477"
   clusterConfig:
     catalogLabelSelector:
       matchLabels:

--- a/examples/simple-trino-cluster-resource-limits.yaml
+++ b/examples/simple-trino-cluster-resource-limits.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-trino
 spec:
   image:
-    productVersion: "476"
+    productVersion: "477"
   clusterConfig:
     catalogLabelSelector: {}
   coordinators:

--- a/examples/simple-trino-cluster-s3.yaml
+++ b/examples/simple-trino-cluster-s3.yaml
@@ -7,7 +7,7 @@ metadata:
   name: simple-trino
 spec:
   image:
-    productVersion: "476"
+    productVersion: "477"
   clusterConfig:
     catalogLabelSelector:
       matchLabels:

--- a/examples/simple-trino-cluster.yaml
+++ b/examples/simple-trino-cluster.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-trino
 spec:
   image:
-    productVersion: "476"
+    productVersion: "477"
   clusterConfig:
     catalogLabelSelector:
       matchLabels:

--- a/examples/simple-trino-oauth2.yaml
+++ b/examples/simple-trino-oauth2.yaml
@@ -91,7 +91,7 @@ metadata:
   name: simple-trino
 spec:
   image:
-    productVersion: "476"
+    productVersion: "477"
   clusterConfig:
     authentication:
       - authenticationClass: simple-trino-oidc

--- a/rust/operator-binary/src/authentication/mod.rs
+++ b/rust/operator-binary/src/authentication/mod.rs
@@ -670,7 +670,7 @@ mod tests {
     fn resolved_product_image() -> ResolvedProductImage {
         ResolvedProductImage {
             product_version: "".to_string(),
-            app_version_label_value: "470".parse().expect("static label value is always valid"),
+            app_version_label_value: "477".parse().expect("static label value is always valid"),
             image: "".to_string(),
             image_pull_policy: "".to_string(),
             pull_secrets: None,

--- a/rust/operator-binary/src/authentication/password/mod.rs
+++ b/rust/operator-binary/src/authentication/password/mod.rs
@@ -251,7 +251,7 @@ mod tests {
         TrinoPasswordAuthentication::new(authenticators)
             .password_authentication_config(&ResolvedProductImage {
                 product_version: "".to_string(),
-                app_version_label_value: "470".parse().expect("static label value is always valid"),
+                app_version_label_value: "477".parse().expect("static label value is always valid"),
                 image: "".to_string(),
                 image_pull_policy: "".to_string(),
                 pull_secrets: None,

--- a/rust/operator-binary/src/config/jvm.rs
+++ b/rust/operator-binary/src/config/jvm.rs
@@ -172,7 +172,7 @@ mod tests {
           name: simple-trino
         spec:
           image:
-            productVersion: "470"
+            productVersion: "477"
           clusterConfig:
             catalogLabelSelector: {}
           coordinators:
@@ -216,7 +216,7 @@ mod tests {
           name: simple-trino
         spec:
           image:
-            productVersion: "470"
+            productVersion: "477"
           clusterConfig:
             catalogLabelSelector: {}
           coordinators:

--- a/rust/operator-binary/src/config/jvm.rs
+++ b/rust/operator-binary/src/config/jvm.rs
@@ -129,9 +129,9 @@ fn recommended_trino_jvm_args(product_version: u16) -> Result<Vec<String>, Error
             "-XX:G1NumCollectionsKeepPinned=10000000".to_owned(),
         ]),
         // Copied from:
-        // - https://trino.io/docs/470/installation/deployment.html#jvm-config
         // - https://trino.io/docs/476/installation/deployment.html#jvm-config
-        470 | 476 => Ok(vec![
+        // - https://trino.io/docs/477/installation/deployment.html#jvm-config
+        476 | 477 => Ok(vec![
             "-XX:InitialRAMPercentage=80".to_owned(),
             "-XX:MaxRAMPercentage=80".to_owned(),
             "-XX:G1HeapRegionSize=32M".to_owned(),

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -1847,7 +1847,7 @@ mod tests {
           name: simple-trino
         spec:
           image:
-            productVersion: "470"
+            productVersion: "477"
           clusterConfig:
             catalogLabelSelector:
               matchLabels:
@@ -1905,7 +1905,7 @@ mod tests {
           name: simple-trino
         spec:
           image:
-            productVersion: "470"
+            productVersion: "477"
           clusterConfig:
             catalogLabelSelector:
               matchLabels:
@@ -2094,7 +2094,7 @@ mod tests {
           name: trino
         spec:
           image:
-            productVersion: "470"
+            productVersion: "477"
           clusterConfig:
             catalogLabelSelector:
               matchLabels:
@@ -2146,7 +2146,7 @@ mod tests {
           name: trino
         spec:
           image:
-            productVersion: "470"
+            productVersion: "477"
           clusterConfig:
             catalogLabelSelector:
               matchLabels:

--- a/rust/operator-binary/src/crd/affinity.rs
+++ b/rust/operator-binary/src/crd/affinity.rs
@@ -115,7 +115,7 @@ mod tests {
           name: simple-trino
         spec:
           image:
-            productVersion: "470"
+            productVersion: "477"
           clusterConfig:
             catalogLabelSelector:
               matchLabels:
@@ -203,7 +203,7 @@ mod tests {
           name: simple-trino
         spec:
           image:
-            productVersion: "470"
+            productVersion: "477"
           clusterConfig:
             catalogLabelSelector:
               matchLabels:

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -1031,7 +1031,7 @@ mod tests {
           name: simple-trino
         spec:
           image:
-            productVersion: "470"
+            productVersion: "477"
           clusterConfig:
             catalogLabelSelector: {}
         "#;
@@ -1047,7 +1047,7 @@ mod tests {
           name: simple-trino
         spec:
           image:
-            productVersion: "470"
+            productVersion: "477"
           clusterConfig:
             catalogLabelSelector: {}
             tls:
@@ -1065,7 +1065,7 @@ mod tests {
           name: simple-trino
         spec:
           image:
-            productVersion: "470"
+            productVersion: "477"
           clusterConfig:
             catalogLabelSelector: {}
             tls:
@@ -1084,7 +1084,7 @@ mod tests {
           name: simple-trino
         spec:
           image:
-            productVersion: "470"
+            productVersion: "477"
           clusterConfig:
             catalogLabelSelector: {}
             tls:
@@ -1105,7 +1105,7 @@ mod tests {
           name: simple-trino
         spec:
           image:
-            productVersion: "470"
+            productVersion: "477"
           clusterConfig:
             catalogLabelSelector: {}
         "#;
@@ -1121,7 +1121,7 @@ mod tests {
           name: simple-trino
         spec:
           image:
-            productVersion: "470"
+            productVersion: "477"
           clusterConfig:
             catalogLabelSelector: {}
             tls:
@@ -1139,7 +1139,7 @@ mod tests {
           name: simple-trino
         spec:
           image:
-            productVersion: "470"
+            productVersion: "477"
           clusterConfig:
             catalogLabelSelector: {}
             tls:
@@ -1161,7 +1161,7 @@ mod tests {
           name: simple-trino
         spec:
           image:
-            productVersion: "470"
+            productVersion: "477"
           clusterConfig:
             catalogLabelSelector: {}
         "#;
@@ -1182,7 +1182,7 @@ mod tests {
           name: simple-trino
         spec:
           image:
-            productVersion: "470"
+            productVersion: "477"
           clusterConfig:
             catalogLabelSelector: {}
           workers:
@@ -1209,7 +1209,7 @@ mod tests {
           name: simple-trino
         spec:
           image:
-            productVersion: "470"
+            productVersion: "477"
           clusterConfig:
             catalogLabelSelector: {}
           workers:

--- a/tests/templates/kuttl/opa-authorization/check-opa.py.j2
+++ b/tests/templates/kuttl/opa-authorization/check-opa.py.j2
@@ -51,11 +51,7 @@ TEST_DATA = [
             {
                 "query": "SET SESSION iceberg.test=true",
                 # The requests are authorized, just a fake property
-{% if test_scenario['values']['trino'] == '470' %}
-                "error": "Session property iceberg.test does not exist",
-{% else %}
                 "error": "Session property 'iceberg.test' does not exist",
-{% endif %}
             },
             # ## SCHEMA ##
             # ExecuteQuery, AccessCatalog, ShowSchemas, SelectFromColumns, FilterCatalogs, FilterSchemas

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -20,15 +20,15 @@ dimensions:
   - name: trino
     values:
       - "451"
-      - "470"
       - "476"
+      - "477"
       # To use a custom image, add a comma and the full name after the product version
-      # - 470,oci.stackable.tech/sdp/trino:470-stackable0.0.0-dev
+      # - 477,oci.stackable.tech/sdp/trino:477-stackable0.0.0-dev
   - name: trino-latest
     values:
-      - "476"
+      - "477"
       # To use a custom image, add a comma and the full name after the product version
-      # - 470,oci.stackable.tech/sdp/trino:470-stackable0.0.0-dev
+      # - 477,oci.stackable.tech/sdp/trino:477-stackable0.0.0-dev
   - name: hive
     values:
       - 3.1.3


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1242

Smoke tests with updated Trino, Trino CLI and Trino operator images passed:

```
--- PASS: kuttl (487.69s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_trino-477_hive-4.0.1_opa-1.4.2_hdfs-3.4.1_zookeeper-3.9.3_openshift-false (487.36s)
PASS
```