### PR TITLE
chore: Bump zookeeper version for 25.11.0

### DIFF
--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -45,6 +45,7 @@ dimensions:
   - name: zookeeper
     values:
       - 3.9.3
+      - 3.9.4
   - name: keycloak
     values:
       - 25.0.0


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/docker-images/issues/1275

### Integrationtests

```
--- FAIL: kuttl (6518.83s)
    --- FAIL: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/orphaned-resources_trino-latest-477_openshift-false (356.66s)
        --- PASS: kuttl/harness/fault-tolerant-execution_trino-476_openshift-false (406.91s)
        --- PASS: kuttl/harness/tls_trino-latest-477_use-authentication-false_use-tls-false_use-internal-tls-false_openshift-false (78.89s)
        --- PASS: kuttl/harness/listener_trino-477_openshift-false (80.47s)
        --- PASS: kuttl/harness/fault-tolerant-execution_trino-451_openshift-false (179.98s)
        --- PASS: kuttl/harness/listener_trino-476_openshift-false (93.07s)
        --- PASS: kuttl/harness/listener_trino-451_openshift-false (91.10s)
        --- PASS: kuttl/harness/smoke_trino-451_hive-4.0.1_opa-1.8.0_hdfs-3.4.2_zookeeper-3.9.4_openshift-false (547.62s)
        --- PASS: kuttl/harness/opa-authorization_trino-477_hive-latest-4.0.1_opa-1.8.0_keycloak-25.0.0_openshift-false (530.29s)
        --- PASS: kuttl/harness/smoke_trino-477_hive-4.0.1_opa-1.8.0_hdfs-3.4.2_zookeeper-3.9.4_openshift-false (433.79s)
        --- PASS: kuttl/harness/opa-authorization_trino-476_hive-latest-4.0.1_opa-1.8.0_keycloak-25.0.0_openshift-false (435.48s)
        --- PASS: kuttl/harness/smoke_trino-477_hive-4.0.1_opa-1.8.0_hdfs-3.4.2_zookeeper-3.9.3_openshift-false (429.09s)
        --- PASS: kuttl/harness/opa-authorization_trino-451_hive-latest-4.0.1_opa-1.8.0_keycloak-25.0.0_openshift-false (444.73s)
        --- PASS: kuttl/harness/authentication_trino-latest-477_ldap-use-tls-true_openshift-false (347.79s)
        --- PASS: kuttl/harness/smoke_trino-477_hive-3.1.3_opa-1.8.0_hdfs-3.4.2_zookeeper-3.9.4_openshift-false (553.66s)
        --- PASS: kuttl/harness/authentication_trino-latest-477_ldap-use-tls-false_openshift-false (281.21s)
        --- PASS: kuttl/harness/smoke_trino-477_hive-3.1.3_opa-1.8.0_hdfs-3.4.2_zookeeper-3.9.3_openshift-false (693.92s)
        --- PASS: kuttl/harness/client-spooling_trino-latest-477_openshift-false (167.97s)
        --- PASS: kuttl/harness/tls_trino-latest-477_use-authentication-true_use-tls-true_use-internal-tls-true_openshift-false (81.34s)
        --- PASS: kuttl/harness/tls_trino-latest-477_use-authentication-true_use-tls-true_use-internal-tls-false_openshift-false (79.44s)
        --- PASS: kuttl/harness/smoke_trino-476_hive-4.0.1_opa-1.8.0_hdfs-3.4.2_zookeeper-3.9.4_openshift-false (664.00s)
        --- PASS: kuttl/harness/tls_trino-latest-477_use-authentication-true_use-tls-false_use-internal-tls-true_openshift-false (75.87s)
        --- PASS: kuttl/harness/tls_trino-latest-477_use-authentication-true_use-tls-false_use-internal-tls-false_openshift-false (115.60s)
        --- PASS: kuttl/harness/tls_trino-latest-477_use-authentication-false_use-tls-true_use-internal-tls-true_openshift-false (80.02s)
        --- PASS: kuttl/harness/smoke_trino-476_hive-4.0.1_opa-1.8.0_hdfs-3.4.2_zookeeper-3.9.3_openshift-false (433.90s)
        --- PASS: kuttl/harness/tls_trino-latest-477_use-authentication-false_use-tls-true_use-internal-tls-false_openshift-false (79.28s)
        --- PASS: kuttl/harness/smoke_trino-476_hive-3.1.3_opa-1.8.0_hdfs-3.4.2_zookeeper-3.9.4_openshift-false (554.41s)
        --- PASS: kuttl/harness/tls_trino-latest-477_use-authentication-false_use-tls-false_use-internal-tls-true_openshift-false (73.50s)
        --- PASS: kuttl/harness/logging_trino-477_openshift-false (85.26s)
        --- PASS: kuttl/harness/smoke_trino-476_hive-3.1.3_opa-1.8.0_hdfs-3.4.2_zookeeper-3.9.3_openshift-false (488.25s)
        --- PASS: kuttl/harness/fault-tolerant-execution_trino-477_openshift-false (120.75s)
        --- PASS: kuttl/harness/smoke_trino-451_hive-4.0.1_opa-1.8.0_hdfs-3.4.2_zookeeper-3.9.3_openshift-false (498.80s)
        --- PASS: kuttl/harness/logging_trino-451_openshift-false (91.60s)
        --- PASS: kuttl/harness/logging_trino-476_openshift-false (91.42s)
        --- PASS: kuttl/harness/resources_trino-latest-477_openshift-false (89.88s)
        --- PASS: kuttl/harness/cluster-operation_trino-latest-477_openshift-false (65.85s)
        --- PASS: kuttl/harness/smoke_trino-451_hive-3.1.3_opa-1.8.0_hdfs-3.4.2_zookeeper-3.9.4_openshift-false (939.35s)
        --- FAIL: kuttl/harness/smoke_trino-451_hive-3.1.3_opa-1.8.0_hdfs-3.4.2_zookeeper-3.9.3_openshift-false (1254.02s)
FAIL

--- PASS: kuttl (520.52s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_trino-451_hive-3.1.3_opa-1.8.0_hdfs-3.4.2_zookeeper-3.9.3_openshift-false (520.50s)
PASS
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
