### PR TITLE
test: Enable OPA logging in kuttl tests

### DIFF
--- a/tests/templates/kuttl/opa-authorization/12-stop-opa.yaml.j2
+++ b/tests/templates/kuttl/opa-authorization/12-stop-opa.yaml.j2
@@ -14,5 +14,8 @@ spec:
     vectorAggregatorConfigMapName: vector-aggregator-discovery
 {% endif %}
   servers:
+    config:
+      logging:
+        enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
       default: {}

--- a/tests/templates/kuttl/smoke/09-install-opa.yaml.j2
+++ b/tests/templates/kuttl/smoke/09-install-opa.yaml.j2
@@ -12,6 +12,9 @@ spec:
     vectorAggregatorConfigMapName: vector-aggregator-discovery
 {% endif %}
   servers:
+    config:
+      logging:
+        enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
       default: {}
 ---

--- a/tests/templates/kuttl/smoke_aws/09-install-opa.yaml.j2
+++ b/tests/templates/kuttl/smoke_aws/09-install-opa.yaml.j2
@@ -12,6 +12,9 @@ spec:
     vectorAggregatorConfigMapName: vector-aggregator-discovery
 {% endif %}
   servers:
+    config:
+      logging:
+        enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
       default: {}
 ---


### PR DESCRIPTION
I wanted to have a look at the OPA logs in CI tests and noticed we don't ship logs there