### PR TITLE
test: Remove ZooKeeper 3.9.3

### DIFF
--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -44,7 +44,6 @@ dimensions:
       - 3.4.2
   - name: zookeeper
     values:
-      - 3.9.3
       - 3.9.4
   - name: keycloak
     values:


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1384

remove ZooKeeper 3.9.3 from tests