### PR TITLE
test: Remove generation assertion in smoke test

### DIFF
--- a/tests/templates/kuttl/smoke/10-assert.yaml
+++ b/tests/templates/kuttl/smoke/10-assert.yaml
@@ -9,7 +9,6 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: trino-coordinator-default
-  generation: 1 # There should be no unneeded Pod restarts
   labels:
     restarter.stackable.tech/enabled: "true"
 spec:
@@ -24,7 +23,6 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: trino-worker-default
-  generation: 1 # There should be no unneeded Pod restarts
   labels:
     restarter.stackable.tech/enabled: "true"
 spec:


### PR DESCRIPTION
This caused problems when running the tests on @xeniape laptop, likely due too many things (controllers, reflectors, webhooks etc.) running asynchronously 