### PR TITLE
test: Increase memory of test helper container

### DIFF
--- a/tests/templates/kuttl/client-spooling/03-install-test-helper.yaml
+++ b/tests/templates/kuttl/client-spooling/03-install-test-helper.yaml
@@ -15,8 +15,8 @@ spec:
         - "sleep infinity"
       resources:
         requests:
-          cpu: "250m"
-          memory: "1024Mi"
+          cpu: 250m
+          memory: 2Gi
         limits:
-          cpu: "250m"
-          memory: "2048Mi"
+          cpu: "1"
+          memory: 2Gi


### PR DESCRIPTION
Only Python things...

```
    logger.go:42: 01:09:43 | client-spooling_trino-latest-479_openshift-false/5-run-tests | running command: [sh -c kubectl exec -n $NAMESPACE trino-test-helper -- python /tmp/04_query.py -c trino-coordinator]
    logger.go:42: 01:12:37 | client-spooling_trino-latest-479_openshift-false/5-run-tests | command terminated with exit code 137
```