### PR TITLE
chore: Bump Rust edition to 2024

### DIFF
--- a/Cargo.nix
+++ b/Cargo.nix
@@ -9996,7 +9996,7 @@ rec {
       "stackable-trino-operator" = rec {
         crateName = "stackable-trino-operator";
         version = "0.0.0-dev";
-        edition = "2021";
+        edition = "2024";
         crateBin = [
           {
             name = "stackable-trino-operator";

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 version = "0.0.0-dev"
 authors = ["Stackable GmbH <info@stackable.tech>"]
 license = "OSL-3.0"
-edition = "2021"
+edition = "2024"
 repository = "https://github.com/stackabletech/trino-operator"
 
 [workspace.dependencies]

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -526,8 +526,8 @@ pub async fn reconcile_trino(
             );
         }
 
-        if let Some(listener_class) = trino_role.listener_class_name(trino) {
-            if let Some(listener_group_name) = group_listener_name(trino, &trino_role) {
+        if let Some(listener_class) = trino_role.listener_class_name(trino)
+            && let Some(listener_group_name) = group_listener_name(trino, &trino_role) {
                 let role_group_listener = build_group_listener(
                     trino,
                     build_recommended_labels(
@@ -546,7 +546,6 @@ pub async fn reconcile_trino(
                     .await
                     .context(ApplyGroupListenerSnafu)?;
             }
-        }
 
         let role_config = trino.generic_role_config(&trino_role);
         if let Some(GenericRoleConfig {

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -527,25 +527,26 @@ pub async fn reconcile_trino(
         }
 
         if let Some(listener_class) = trino_role.listener_class_name(trino)
-            && let Some(listener_group_name) = group_listener_name(trino, &trino_role) {
-                let role_group_listener = build_group_listener(
+            && let Some(listener_group_name) = group_listener_name(trino, &trino_role)
+        {
+            let role_group_listener = build_group_listener(
+                trino,
+                build_recommended_labels(
                     trino,
-                    build_recommended_labels(
-                        trino,
-                        &validated.image.app_version_label_value,
-                        &trino_role_str,
-                        "none",
-                    ),
-                    listener_class.to_string(),
-                    listener_group_name,
-                )
-                .context(ListenerConfigurationSnafu)?;
+                    &validated.image.app_version_label_value,
+                    &trino_role_str,
+                    "none",
+                ),
+                listener_class.to_string(),
+                listener_group_name,
+            )
+            .context(ListenerConfigurationSnafu)?;
 
-                cluster_resources
-                    .add(client, role_group_listener)
-                    .await
-                    .context(ApplyGroupListenerSnafu)?;
-            }
+            cluster_resources
+                .add(client, role_group_listener)
+                .await
+                .context(ApplyGroupListenerSnafu)?;
+        }
 
         let role_config = trino.generic_role_config(&trino_role);
         if let Some(GenericRoleConfig {

--- a/rust/operator-binary/src/webhooks/conversion.rs
+++ b/rust/operator-binary/src/webhooks/conversion.rs
@@ -46,7 +46,7 @@ pub async fn create_webhook_server(
         field_manager: FIELD_MANAGER.to_owned(),
     };
 
-    let (conversion_webhook, _initial_reconcile_rx) =
+    let (conversion_webhook, _) =
         ConversionWebhook::new(crds_and_handlers, client, conversion_webhook_options);
 
     let webhook_server_options = WebhookServerOptions {


### PR DESCRIPTION
- Apply `cargo fix --edition` changes
- Use `&& let` chaining instead of nested `if let` (Clippy suggested)
- Fix Rust 2024 drop order warning by dropping unused binding

Part of https://github.com/stackabletech/issues/issues/832

## Description

*Please add a description here. This will become the commit message of the merge request later.*

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
