### PR TITLE
refactor: Extract apply and update_status steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,13 @@ All notable changes to this project will be documented in this file.
   functions and carry the full set of recommended labels ([#913]).
 - BREAKING: The `coordinators` and `workers` roles are now required by the CRD.
   Previously a TrinoCluster missing either role was accepted by the API server but failed reconciliation ([#913]).
+- The reconciler now applies resources and derives the cluster status in discrete
+  apply and update_status steps for the `trino_controller` ([#923]).
 
 [#909]: https://github.com/stackabletech/trino-operator/pull/909
 [#913]: https://github.com/stackabletech/trino-operator/pull/913
 [#918]: https://github.com/stackabletech/trino-operator/pull/918
+[#923]: https://github.com/stackabletech/trino-operator/pull/923
 
 ## [26.7.0] - 2026-07-21
 

--- a/rust/operator-binary/src/controller/apply.rs
+++ b/rust/operator-binary/src/controller/apply.rs
@@ -1,0 +1,179 @@
+//! The apply step in the TrinoCluster controller.
+
+use std::marker::PhantomData;
+
+use snafu::{ResultExt, Snafu};
+use stackable_operator::{
+    client::Client,
+    cluster_resources::{ClusterResource, ClusterResourceApplyStrategy, ClusterResources},
+    commons::random_secret_creation,
+    deep_merger::ObjectOverrides,
+    v2::cluster_resources::cluster_resources_new,
+};
+use strum::{EnumDiscriminants, IntoStaticStr};
+
+use crate::{
+    controller::{
+        Applied, KubernetesResources, Prepared, ValidatedCluster, controller_name, operator_name,
+        product_name, shared_internal_secret_name, shared_spooling_secret_name,
+    },
+    crd::{ENV_INTERNAL_SECRET, ENV_SPOOLING_SECRET},
+};
+
+#[derive(Snafu, Debug, EnumDiscriminants)]
+#[strum_discriminants(derive(IntoStaticStr))]
+pub enum Error {
+    #[snafu(display("failed to apply Kubernetes resource"))]
+    ApplyResource {
+        source: stackable_operator::cluster_resources::Error,
+    },
+
+    #[snafu(display("failed to delete orphaned resources"))]
+    DeleteOrphanedResources {
+        source: stackable_operator::cluster_resources::Error,
+    },
+
+    #[snafu(display("failed to create internal secret"))]
+    CreateInternalSecret {
+        source: random_secret_creation::Error,
+    },
+}
+
+type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Applier for the Kubernetes resource specifications produced by this controller.
+///
+/// The implementation is not tied to this controller and could theoretically be moved to
+/// stackable_operator if [`KubernetesResources`] would contain all possible resource types.
+pub struct Applier<'a> {
+    client: &'a Client,
+    cluster_resources: ClusterResources<'a>,
+}
+
+impl<'a> Applier<'a> {
+    pub fn new(
+        client: &'a Client,
+        cluster: &ValidatedCluster,
+        apply_strategy: ClusterResourceApplyStrategy,
+        object_overrides: &'a ObjectOverrides,
+    ) -> Applier<'a> {
+        let cluster_resources = cluster_resources_new(
+            &product_name(),
+            &operator_name(),
+            &controller_name(),
+            &cluster.name,
+            &cluster.namespace,
+            &cluster.uid,
+            apply_strategy,
+            object_overrides,
+        );
+
+        Applier {
+            client,
+            cluster_resources,
+        }
+    }
+
+    /// Applies the given Kubernetes resources and marks them as applied.
+    ///
+    /// Resources that are owned by this cluster but no longer part of `resources` are deleted
+    /// afterwards.
+    pub async fn apply(
+        mut self,
+        resources: KubernetesResources<Prepared>,
+    ) -> Result<KubernetesResources<Applied>> {
+        // Destructured without `..`, so that adding a field to [`KubernetesResources`] fails to
+        // compile here instead of the new resource silently never being applied.
+        let KubernetesResources {
+            stateful_sets,
+            services,
+            listeners,
+            config_maps,
+            pod_disruption_budgets,
+            service_accounts,
+            role_bindings,
+            status: _,
+        } = resources;
+
+        // The ServiceAccount comes first, because the Pods reference it at creation time.
+        let service_accounts = self.add_resources(service_accounts).await?;
+        let role_bindings = self.add_resources(role_bindings).await?;
+        let services = self.add_resources(services).await?;
+        let listeners = self.add_resources(listeners).await?;
+        let config_maps = self.add_resources(config_maps).await?;
+        let pod_disruption_budgets = self.add_resources(pod_disruption_budgets).await?;
+
+        // Note: The StatefulSet needs to be applied after all ConfigMaps and Secrets it mounts
+        // to prevent unnecessary Pod restarts.
+        // See https://github.com/stackabletech/commons-operator/issues/111 for details.
+        let stateful_sets = self.add_resources(stateful_sets).await?;
+
+        self.cluster_resources
+            .delete_orphaned_resources(self.client)
+            .await
+            .context(DeleteOrphanedResourcesSnafu)?;
+
+        Ok(KubernetesResources {
+            stateful_sets,
+            services,
+            listeners,
+            config_maps,
+            pod_disruption_budgets,
+            service_accounts,
+            role_bindings,
+            status: PhantomData,
+        })
+    }
+
+    /// Applies the given resources and returns them as the API server echoed them back.
+    async fn add_resources<T: ClusterResource + Sync>(
+        &mut self,
+        resources: Vec<T>,
+    ) -> Result<Vec<T>> {
+        let mut applied_resources = vec![];
+
+        for resource in resources {
+            let applied_resource = self
+                .cluster_resources
+                .add(self.client, resource)
+                .await
+                .context(ApplyResourceSnafu)?;
+            applied_resources.push(applied_resource);
+        }
+
+        Ok(applied_resources)
+    }
+}
+
+/// Ensures the two shared random Secrets (internal communication and spooling) exist, creating
+/// any that are missing.
+///
+/// These are read-or-create client operations, so they cannot be part of the client-free
+/// `build()` step. They are also deliberately not tracked in [`ClusterResources`], so that they
+/// survive orphan deletion and an existing Secret is never overwritten (rotating them would
+/// invalidate all running queries).
+pub async fn ensure_random_secrets(client: &Client, cluster: &ValidatedCluster) -> Result<()> {
+    random_secret_creation::create_random_secret_if_not_exists(
+        &shared_internal_secret_name(&cluster.name),
+        ENV_INTERNAL_SECRET,
+        512,
+        cluster,
+        client,
+    )
+    .await
+    .context(CreateInternalSecretSnafu)?;
+
+    // This secret is created even if spooling is not configured.
+    // Trino currently requires the secret to be exactly 256 bits long.
+    random_secret_creation::create_random_secret_if_not_exists(
+        &shared_spooling_secret_name(&cluster.name),
+        ENV_SPOOLING_SECRET,
+        32,
+        cluster,
+        client,
+    )
+    .await
+    .context(CreateInternalSecretSnafu)?;
+
+    Ok(())
+}

--- a/rust/operator-binary/src/controller/apply.rs
+++ b/rust/operator-binary/src/controller/apply.rs
@@ -37,6 +37,11 @@ pub enum Error {
     CreateInternalSecret {
         source: random_secret_creation::Error,
     },
+
+    #[snafu(display("failed to create spooling secret"))]
+    CreateSpoolingSecret {
+        source: random_secret_creation::Error,
+    },
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
@@ -173,7 +178,7 @@ pub async fn ensure_random_secrets(client: &Client, cluster: &ValidatedCluster) 
         client,
     )
     .await
-    .context(CreateInternalSecretSnafu)?;
+    .context(CreateSpoolingSecretSnafu)?;
 
     Ok(())
 }

--- a/rust/operator-binary/src/controller/build.rs
+++ b/rust/operator-binary/src/controller/build.rs
@@ -1,6 +1,6 @@
 //! Builders that turn a `ValidatedCluster` into Kubernetes resource contents.
 
-use std::str::FromStr;
+use std::{marker::PhantomData, str::FromStr};
 
 use snafu::{ResultExt, Snafu};
 use stackable_operator::{
@@ -11,7 +11,7 @@ use stackable_operator::{
 };
 
 use crate::controller::{
-    KubernetesResources, ValidatedCluster,
+    KubernetesResources, Prepared, ValidatedCluster,
     build::resource::{
         config_map,
         listener::{build_group_listener, group_listener_name},
@@ -59,7 +59,7 @@ pub enum Error {
 pub fn build(
     cluster: &ValidatedCluster,
     cluster_info: &KubernetesClusterInfo,
-) -> Result<KubernetesResources, Error> {
+) -> Result<KubernetesResources<Prepared>, Error> {
     let mut stateful_sets = vec![];
     let mut services = vec![];
     let mut listeners = vec![];
@@ -148,6 +148,7 @@ pub fn build(
         pod_disruption_budgets,
         service_accounts: vec![build_service_account(cluster)],
         role_bindings: vec![build_role_binding(cluster)],
+        status: PhantomData,
     })
 }
 

--- a/rust/operator-binary/src/controller/mod.rs
+++ b/rust/operator-binary/src/controller/mod.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, str::FromStr};
+use std::{collections::BTreeMap, marker::PhantomData, str::FromStr};
 
 use stackable_operator::{
     commons::{
@@ -67,8 +67,16 @@ pub(crate) fn shared_spooling_secret_name(cluster_name: &ClusterName) -> String 
 // Placeholder version label value for resources whose labels must not change after deployment.
 stackable_operator::constant!(UNVERSIONED_PRODUCT_VERSION: ProductVersion = "none");
 
+/// Marker for prepared Kubernetes resources which are not applied yet.
+pub struct Prepared;
+
 /// Every Kubernetes resource produced by the client-free [`build()`](build::build) step.
-pub struct KubernetesResources {
+///
+/// `T` marks how far the resources have travelled through the reconcile pipeline (currently
+/// [`Prepared`], later also applied). The marker lets the type system enforce, for example, that
+/// the cluster status is derived from the resources the API server returned rather than from the
+/// ones we merely built.
+pub struct KubernetesResources<T> {
     pub stateful_sets: Vec<StatefulSet>,
     pub services: Vec<Service>,
     pub listeners: Vec<Listener>,
@@ -76,6 +84,7 @@ pub struct KubernetesResources {
     pub pod_disruption_budgets: Vec<PodDisruptionBudget>,
     pub service_accounts: Vec<ServiceAccount>,
     pub role_bindings: Vec<RoleBinding>,
+    pub status: PhantomData<T>,
 }
 
 #[derive(Clone, Debug)]

--- a/rust/operator-binary/src/controller/mod.rs
+++ b/rust/operator-binary/src/controller/mod.rs
@@ -43,6 +43,7 @@ use crate::{
     trino_controller::{CONTROLLER_NAME, OPERATOR_NAME},
 };
 
+pub(crate) mod apply;
 pub(crate) mod build;
 pub(crate) mod dereference;
 pub(crate) mod validate;
@@ -70,12 +71,14 @@ stackable_operator::constant!(UNVERSIONED_PRODUCT_VERSION: ProductVersion = "non
 /// Marker for prepared Kubernetes resources which are not applied yet.
 pub struct Prepared;
 
+/// Marker for Kubernetes resources which have been applied to the Kubernetes cluster.
+pub struct Applied;
+
 /// Every Kubernetes resource produced by the client-free [`build()`](build::build) step.
 ///
-/// `T` marks how far the resources have travelled through the reconcile pipeline (currently
-/// [`Prepared`], later also applied). The marker lets the type system enforce, for example, that
-/// the cluster status is derived from the resources the API server returned rather than from the
-/// ones we merely built.
+/// `T` marks whether these resources are only [`Prepared`] or already [`Applied`]. The marker
+/// lets the type system enforce, for example, that the cluster status is derived from the
+/// resources the API server returned rather than from the ones we merely built.
 pub struct KubernetesResources<T> {
     pub stateful_sets: Vec<StatefulSet>,
     pub services: Vec<Service>,

--- a/rust/operator-binary/src/controller/mod.rs
+++ b/rust/operator-binary/src/controller/mod.rs
@@ -46,6 +46,7 @@ use crate::{
 pub(crate) mod apply;
 pub(crate) mod build;
 pub(crate) mod dereference;
+pub(crate) mod update_status;
 pub(crate) mod validate;
 
 pub use stackable_operator::v2::product_logging::framework::STACKABLE_LOG_DIR;

--- a/rust/operator-binary/src/controller/update_status.rs
+++ b/rust/operator-binary/src/controller/update_status.rs
@@ -1,0 +1,61 @@
+//! The update_status step in the TrinoCluster controller.
+
+use snafu::{ResultExt, Snafu};
+use stackable_operator::{
+    client::Client,
+    status::condition::{
+        compute_conditions, operations::ClusterOperationsConditionBuilder,
+        statefulset::StatefulSetConditionBuilder,
+    },
+};
+use strum::{EnumDiscriminants, IntoStaticStr};
+
+use crate::{
+    controller::{Applied, KubernetesResources},
+    crd::v1alpha1,
+    trino_controller::OPERATOR_NAME,
+};
+
+#[derive(Snafu, Debug, EnumDiscriminants)]
+#[strum_discriminants(derive(IntoStaticStr))]
+pub enum Error {
+    #[snafu(display("failed to update status"))]
+    ApplyStatus {
+        source: stackable_operator::client::Error,
+    },
+}
+
+type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Computes the cluster status from the applied resources and patches it onto the
+/// [`v1alpha1::TrinoCluster`].
+///
+/// Takes [`KubernetesResources<Applied>`], so the type system proves that the status is derived
+/// from the resources the API server acknowledged and not from the ones we merely built.
+pub async fn update_status(
+    client: &Client,
+    trino: &v1alpha1::TrinoCluster,
+    applied: &KubernetesResources<Applied>,
+) -> Result<()> {
+    let mut sts_cond_builder = StatefulSetConditionBuilder::default();
+    for stateful_set in &applied.stateful_sets {
+        sts_cond_builder.add(stateful_set.clone());
+    }
+
+    let cluster_operation_cond_builder =
+        ClusterOperationsConditionBuilder::new(&trino.spec.cluster_operation);
+
+    let status = v1alpha1::TrinoClusterStatus {
+        conditions: compute_conditions(
+            trino,
+            &[&sts_cond_builder, &cluster_operation_cond_builder],
+        ),
+    };
+
+    client
+        .apply_patch_status(OPERATOR_NAME, trino, &status)
+        .await
+        .context(ApplyStatusSnafu)?;
+
+    Ok(())
+}

--- a/rust/operator-binary/src/controller/update_status.rs
+++ b/rust/operator-binary/src/controller/update_status.rs
@@ -31,15 +31,16 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 /// [`v1alpha1::TrinoCluster`].
 ///
 /// Takes [`KubernetesResources<Applied>`], so the type system proves that the status is derived
-/// from the resources the API server acknowledged and not from the ones we merely built.
+/// from the resources the API server acknowledged and not from the ones we merely built. They are
+/// consumed, because this is the last step of the reconciliation pipeline.
 pub async fn update_status(
     client: &Client,
     trino: &v1alpha1::TrinoCluster,
-    applied: &KubernetesResources<Applied>,
+    applied: KubernetesResources<Applied>,
 ) -> Result<()> {
     let mut sts_cond_builder = StatefulSetConditionBuilder::default();
-    for stateful_set in &applied.stateful_sets {
-        sts_cond_builder.add(stateful_set.clone());
+    for stateful_set in applied.stateful_sets {
+        sts_cond_builder.add(stateful_set);
     }
 
     let cluster_operation_cond_builder =

--- a/rust/operator-binary/src/trino_controller.rs
+++ b/rust/operator-binary/src/trino_controller.rs
@@ -6,7 +6,6 @@ use snafu::{ResultExt, Snafu};
 use stackable_operator::{
     cli::OperatorEnvironmentOptions,
     cluster_resources::ClusterResourceApplyStrategy,
-    commons::random_secret_creation,
     kube::{
         core::{DeserializeGuard, error_boundary},
         runtime::controller::Action,
@@ -17,16 +16,15 @@ use stackable_operator::{
         compute_conditions, operations::ClusterOperationsConditionBuilder,
         statefulset::StatefulSetConditionBuilder,
     },
-    v2::cluster_resources::cluster_resources_new,
 };
 use strum::{EnumDiscriminants, IntoStaticStr};
 
 use crate::{
     controller::{
-        ValidatedCluster, build, controller_name, dereference, operator_name, product_name,
-        shared_internal_secret_name, shared_spooling_secret_name, validate,
+        apply::{self, Applier, ensure_random_secrets},
+        build, dereference, validate,
     },
-    crd::{ENV_INTERNAL_SECRET, ENV_SPOOLING_SECRET, v1alpha1},
+    crd::v1alpha1,
 };
 
 pub struct Ctx {
@@ -43,18 +41,14 @@ pub(crate) const CONTAINER_IMAGE_BASE_NAME: &str = "trino";
 #[derive(Snafu, Debug, EnumDiscriminants)]
 #[strum_discriminants(derive(IntoStaticStr))]
 pub enum Error {
-    #[snafu(display("failed to delete orphaned resources"))]
-    DeleteOrphanedResources {
-        source: stackable_operator::cluster_resources::Error,
-    },
-
     #[snafu(display("failed to build the Kubernetes resources"))]
     BuildResources { source: build::Error },
 
-    #[snafu(display("failed to apply Kubernetes resource"))]
-    ApplyResource {
-        source: stackable_operator::cluster_resources::Error,
-    },
+    #[snafu(display("failed to ensure the shared random Secrets exist"))]
+    EnsureSecrets { source: apply::Error },
+
+    #[snafu(display("failed to apply the Kubernetes resources"))]
+    ApplyResources { source: apply::Error },
 
     #[snafu(display("failed to update status"))]
     ApplyStatus {
@@ -71,11 +65,6 @@ pub enum Error {
 
     #[snafu(display("failed to validate cluster"))]
     ValidateCluster { source: validate::Error },
-
-    #[snafu(display("failed to create internal secret"))]
-    CreateInternalSecret {
-        source: random_secret_creation::Error,
-    },
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
@@ -115,76 +104,29 @@ pub async fn reconcile_trino(
         "Validated TrinoCluster"
     );
 
-    let mut cluster_resources = cluster_resources_new(
-        &product_name(),
-        &operator_name(),
-        &controller_name(),
-        &validated_cluster.name,
-        &validated_cluster.namespace,
-        &validated_cluster.uid,
-        ClusterResourceApplyStrategy::from(&trino.spec.cluster_operation),
-        &trino.spec.object_overrides,
-    );
-
-    ensure_random_secrets(client, &validated_cluster).await?;
-
+    // build (no client required)
     let resources = build::build(&validated_cluster, &client.kubernetes_cluster_info)
         .context(BuildResourcesSnafu)?;
 
+    // apply (client required)
+    ensure_random_secrets(client, &validated_cluster)
+        .await
+        .context(EnsureSecretsSnafu)?;
+
+    let applied = Applier::new(
+        client,
+        &validated_cluster,
+        ClusterResourceApplyStrategy::from(&trino.spec.cluster_operation),
+        &trino.spec.object_overrides,
+    )
+    .apply(resources)
+    .await
+    .context(ApplyResourcesSnafu)?;
+
+    // update status (client required)
     let mut sts_cond_builder = StatefulSetConditionBuilder::default();
-
-    for service_account in resources.service_accounts {
-        cluster_resources
-            .add(client, service_account)
-            .await
-            .context(ApplyResourceSnafu)?;
-    }
-
-    for role_binding in resources.role_bindings {
-        cluster_resources
-            .add(client, role_binding)
-            .await
-            .context(ApplyResourceSnafu)?;
-    }
-
-    for service in resources.services {
-        cluster_resources
-            .add(client, service)
-            .await
-            .context(ApplyResourceSnafu)?;
-    }
-
-    for listener in resources.listeners {
-        cluster_resources
-            .add(client, listener)
-            .await
-            .context(ApplyResourceSnafu)?;
-    }
-
-    for config_map in resources.config_maps {
-        cluster_resources
-            .add(client, config_map)
-            .await
-            .context(ApplyResourceSnafu)?;
-    }
-
-    for pdb in resources.pod_disruption_budgets {
-        cluster_resources
-            .add(client, pdb)
-            .await
-            .context(ApplyResourceSnafu)?;
-    }
-
-    // Note: The StatefulSet needs to be applied after all ConfigMaps and Secrets it mounts
-    // to prevent unnecessary Pod restarts.
-    // See https://github.com/stackabletech/commons-operator/issues/111 for details.
-    for stateful_set in resources.stateful_sets {
-        sts_cond_builder.add(
-            cluster_resources
-                .add(client, stateful_set)
-                .await
-                .context(ApplyResourceSnafu)?,
-        );
+    for stateful_set in &applied.stateful_sets {
+        sts_cond_builder.add(stateful_set.clone());
     }
 
     let cluster_operation_cond_builder =
@@ -197,47 +139,12 @@ pub async fn reconcile_trino(
         ),
     };
 
-    cluster_resources
-        .delete_orphaned_resources(client)
-        .await
-        .context(DeleteOrphanedResourcesSnafu)?;
     client
         .apply_patch_status(OPERATOR_NAME, trino, &status)
         .await
         .context(ApplyStatusSnafu)?;
 
     Ok(Action::await_change())
-}
-
-/// Ensures the two shared random Secrets (internal communication and spooling) exist, creating
-/// any that are missing.
-async fn ensure_random_secrets(
-    client: &stackable_operator::client::Client,
-    cluster: &ValidatedCluster,
-) -> Result<()> {
-    random_secret_creation::create_random_secret_if_not_exists(
-        &shared_internal_secret_name(&cluster.name),
-        ENV_INTERNAL_SECRET,
-        512,
-        cluster,
-        client,
-    )
-    .await
-    .context(CreateInternalSecretSnafu)?;
-
-    // This secret is created even if spooling is not configured.
-    // Trino currently requires the secret to be exactly 256 bits long.
-    random_secret_creation::create_random_secret_if_not_exists(
-        &shared_spooling_secret_name(&cluster.name),
-        ENV_SPOOLING_SECRET,
-        32,
-        cluster,
-        client,
-    )
-    .await
-    .context(CreateInternalSecretSnafu)?;
-
-    Ok(())
 }
 
 pub fn error_policy(

--- a/rust/operator-binary/src/trino_controller.rs
+++ b/rust/operator-binary/src/trino_controller.rs
@@ -126,7 +126,7 @@ pub async fn reconcile_trino(
     .context(ApplyResourcesSnafu)?;
 
     // update status (client required)
-    update_status(client, trino, &applied)
+    update_status(client, trino, applied)
         .await
         .context(UpdateStatusSnafu)?;
 

--- a/rust/operator-binary/src/trino_controller.rs
+++ b/rust/operator-binary/src/trino_controller.rs
@@ -1,4 +1,10 @@
-//! Ensures that `Pod`s are configured and running for each [`v1alpha1::TrinoCluster`]
+//! Ensures that `Pod`s are configured and running for each [`v1alpha1::TrinoCluster`].
+//!
+//! This is the controller driver: it runs the
+//! `dereference -> validate -> build -> apply -> update_status` pipeline. The validated cluster
+//! type and the individual steps live under the [`crate::controller`] module tree; this file is
+//! kept next to `main.rs` for consistency with the other Stackable operators.
+
 use std::sync::Arc;
 
 use const_format::concatcp;
@@ -12,17 +18,15 @@ use stackable_operator::{
     },
     logging::controller::ReconcilerError,
     shared::time::Duration,
-    status::condition::{
-        compute_conditions, operations::ClusterOperationsConditionBuilder,
-        statefulset::StatefulSetConditionBuilder,
-    },
 };
 use strum::{EnumDiscriminants, IntoStaticStr};
 
 use crate::{
     controller::{
         apply::{self, Applier, ensure_random_secrets},
-        build, dereference, validate,
+        build, dereference,
+        update_status::{self, update_status},
+        validate,
     },
     crd::v1alpha1,
 };
@@ -50,10 +54,8 @@ pub enum Error {
     #[snafu(display("failed to apply the Kubernetes resources"))]
     ApplyResources { source: apply::Error },
 
-    #[snafu(display("failed to update status"))]
-    ApplyStatus {
-        source: stackable_operator::client::Error,
-    },
+    #[snafu(display("failed to update the cluster status"))]
+    UpdateStatus { source: update_status::Error },
 
     #[snafu(display("invalid TrinoCluster object"))]
     InvalidTrinoCluster {
@@ -124,25 +126,9 @@ pub async fn reconcile_trino(
     .context(ApplyResourcesSnafu)?;
 
     // update status (client required)
-    let mut sts_cond_builder = StatefulSetConditionBuilder::default();
-    for stateful_set in &applied.stateful_sets {
-        sts_cond_builder.add(stateful_set.clone());
-    }
-
-    let cluster_operation_cond_builder =
-        ClusterOperationsConditionBuilder::new(&trino.spec.cluster_operation);
-
-    let status = v1alpha1::TrinoClusterStatus {
-        conditions: compute_conditions(
-            trino,
-            &[&sts_cond_builder, &cluster_operation_cond_builder],
-        ),
-    };
-
-    client
-        .apply_patch_status(OPERATOR_NAME, trino, &status)
+    update_status(client, trino, &applied)
         .await
-        .context(ApplyStatusSnafu)?;
+        .context(UpdateStatusSnafu)?;
 
     Ok(Action::await_change())
 }


### PR DESCRIPTION
## Description

Completes the `dereference -> validate -> build -> apply -> update_status` pipeline.

- `KubernetesResources` is now generic over a `Prepared`/`Applied` marker, so the
  compiler enforces that the cluster status is derived from the resources the API
  server acknowledged
- new `controller::apply` with an `Applier`, which also takes over
  `ensure_random_secrets` (a read-or-create client operation, deliberately kept out
  of `ClusterResources` so orphan deletion never removes it)
- new `controller::update_status`

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [x] Code contains useful comments
- [ ] Code contains useful logging statements
- [x] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
