### PR TITLE
chore: Upgrade to stackable-operator 0.116.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Internal operator refactoring: introduce a build() step in the reconciler that
   assembles all relevant Kubernetes resources before anything is applied ([#909]).
-- Bump `stackable-operator` to 0.114.0 ([#918]).
+- Bump `stackable-operator` to 0.116.0 ([#918], [#932]).
 - The RBAC ServiceAccount and RoleBinding are now built with the operator-rs `v2::rbac`
   functions and carry the full set of recommended labels ([#913]).
 - BREAKING: The `coordinators` and `workers` roles are now required by the CRD.
@@ -18,6 +18,15 @@ All notable changes to this project will be documented in this file.
 - All product containers now run with `securityContext.runAsNonRoot` set to `true` to improve security ([#925]).
 - Internal operator refactoring: the Trino version is no longer passed to the catalog configuration,
   as no catalog uses it for version-dependent behaviour anymore ([#928]).
+- Environment variable overrides (`envOverrides`) are now merged into the operator-set
+  environment variables by name, so an override replaces the operator's value instead of
+  producing a duplicated entry whose precedence depended on Kubernetes' duplicate-name
+  handling ([#932]).
+- BREAKING: Remove the `app.kubernetes.io/component` and `app.kubernetes.io/role-group` labels
+  from the resources they don't apply to, and the `app.kubernetes.io/version` label from PVC
+  templates (all previously set to the placeholder value `none`). After the operator upgrade,
+  delete each coordinator StatefulSet so that the operator immediately recreates it with the 
+  new labels ([#932]).
 
 ### Fixed
 
@@ -33,6 +42,7 @@ All notable changes to this project will be documented in this file.
 [#923]: https://github.com/stackabletech/trino-operator/pull/923
 [#925]: https://github.com/stackabletech/trino-operator/pull/925
 [#928]: https://github.com/stackabletech/trino-operator/pull/928
+[#932]: https://github.com/stackabletech/trino-operator/pull/932
 
 ## [26.7.0] - 2026-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 - BREAKING: Remove the `app.kubernetes.io/component` and `app.kubernetes.io/role-group` labels
   from the resources they don't apply to, and the `app.kubernetes.io/version` label from PVC
   templates (all previously set to the placeholder value `none`). After the operator upgrade,
-  delete each coordinator StatefulSet so that the operator immediately recreates it with the 
+  delete each coordinator StatefulSet so that the operator immediately recreates it with the
   new labels ([#932]).
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -316,9 +316,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9066c49992464636f92905fa096ec58baaa4d57ec19a5c096c68d3e25ef3d136"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -631,7 +631,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -910,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "flagset"
@@ -959,9 +959,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -974,9 +974,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -984,15 +984,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1001,32 +1001,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-timer"
@@ -1036,9 +1036,9 @@ checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures 0.1.31",
  "futures-channel",
@@ -1154,9 +1154,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1236,9 +1236,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1366,9 +1366,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -1380,9 +1380,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1393,9 +1393,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1407,16 +1407,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -1427,15 +1428,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1604,7 +1605,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link",
 ]
@@ -1653,9 +1654,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1672,7 +1673,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1685,7 +1686,7 @@ dependencies = [
  "pest_derive",
  "regex",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1714,7 +1715,7 @@ dependencies = [
 [[package]]
 name = "k8s-version"
 version = "0.1.3"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#fb2d86579f4e3df008f78f0e527a012243483a2d"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#7b9f9ac9a76fa425ab27f2821377ef86571ca121"
 dependencies = [
  "darling 0.24.0",
  "regex",
@@ -1758,7 +1759,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "either",
- "futures 0.3.33",
+ "futures 0.3.34",
  "http",
  "http-body",
  "http-body-util",
@@ -1777,7 +1778,7 @@ dependencies = [
  "serde",
  "serde-saphyr",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tower",
@@ -1801,7 +1802,7 @@ dependencies = [
  "serde",
  "serde-value",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1829,7 +1830,7 @@ dependencies = [
  "async-stream",
  "backon",
  "educe 0.6.0",
- "futures 0.3.33",
+ "futures 0.3.34",
  "hashbrown 0.16.1",
  "hostname",
  "json-patch",
@@ -1839,7 +1840,7 @@ dependencies = [
  "pin-project",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1892,9 +1893,9 @@ dependencies = [
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -1998,9 +1999,9 @@ checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -2053,7 +2054,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -2095,7 +2096,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tonic",
  "tonic-types",
@@ -2133,7 +2134,7 @@ dependencies = [
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.5",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
 ]
@@ -2215,9 +2216,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
+checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -2225,9 +2226,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
+checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2235,9 +2236,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
+checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2248,9 +2249,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
+checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
 dependencies = [
  "pest",
 ]
@@ -2304,15 +2305,15 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "portable-atomic"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
@@ -2325,9 +2326,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -2513,18 +2514,18 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2745,9 +2746,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3155,7 +3156,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "stackable-certs"
 version = "0.4.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#fb2d86579f4e3df008f78f0e527a012243483a2d"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#7b9f9ac9a76fa425ab27f2821377ef86571ca121"
 dependencies = [
  "const-oid",
  "ecdsa",
@@ -3178,8 +3179,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.115.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#fb2d86579f4e3df008f78f0e527a012243483a2d"
+version = "0.116.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#7b9f9ac9a76fa425ab27f2821377ef86571ca121"
 dependencies = [
  "base64 0.23.1",
  "clap",
@@ -3188,7 +3189,7 @@ dependencies = [
  "dockerfile-parser",
  "educe 0.7.6",
  "either",
- "futures 0.3.33",
+ "futures 0.3.34",
  "http",
  "indexmap",
  "java-properties",
@@ -3223,7 +3224,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator-derive"
 version = "0.3.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#fb2d86579f4e3df008f78f0e527a012243483a2d"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#7b9f9ac9a76fa425ab27f2821377ef86571ca121"
 dependencies = [
  "darling 0.24.0",
  "proc-macro2",
@@ -3234,7 +3235,7 @@ dependencies = [
 [[package]]
 name = "stackable-shared"
 version = "0.1.2"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#fb2d86579f4e3df008f78f0e527a012243483a2d"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#7b9f9ac9a76fa425ab27f2821377ef86571ca121"
 dependencies = [
  "jiff",
  "k8s-openapi",
@@ -3251,7 +3252,7 @@ dependencies = [
 [[package]]
 name = "stackable-telemetry"
 version = "0.6.5"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#fb2d86579f4e3df008f78f0e527a012243483a2d"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#7b9f9ac9a76fa425ab27f2821377ef86571ca121"
 dependencies = [
  "axum",
  "clap",
@@ -3281,7 +3282,7 @@ dependencies = [
  "built",
  "clap",
  "const_format",
- "futures 0.3.33",
+ "futures 0.3.34",
  "indoc",
  "rstest",
  "serde",
@@ -3297,7 +3298,7 @@ dependencies = [
 [[package]]
 name = "stackable-versioned"
 version = "0.11.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#fb2d86579f4e3df008f78f0e527a012243483a2d"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#7b9f9ac9a76fa425ab27f2821377ef86571ca121"
 dependencies = [
  "kube",
  "schemars",
@@ -3311,7 +3312,7 @@ dependencies = [
 [[package]]
 name = "stackable-versioned-macros"
 version = "0.11.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#fb2d86579f4e3df008f78f0e527a012243483a2d"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#7b9f9ac9a76fa425ab27f2821377ef86571ca121"
 dependencies = [
  "convert_case",
  "convert_case_extras",
@@ -3329,7 +3330,7 @@ dependencies = [
 [[package]]
 name = "stackable-webhook"
 version = "0.9.2"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#fb2d86579f4e3df008f78f0e527a012243483a2d"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#7b9f9ac9a76fa425ab27f2821377ef86571ca121"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3461,11 +3462,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -3481,9 +3482,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3531,9 +3532,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3792,7 +3793,7 @@ checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
  "symlink",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "tracing-subscriber",
 ]
@@ -3957,9 +3958,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4019,9 +4020,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4032,9 +4033,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4042,9 +4043,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4052,9 +4053,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4065,18 +4066,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4268,9 +4269,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "x509-cert"
@@ -4378,9 +4379,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4389,9 +4390,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4400,13 +4401,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -489,9 +489,9 @@ rec {
       };
       "async-trait" = rec {
         crateName = "async-trait";
-        version = "0.1.91";
+        version = "0.1.92";
         edition = "2021";
-        sha256 = "1v3cm8mzg66037wm392p1vsdx0lq8bid6y2ivr7z03lpfx0xqdmf";
+        sha256 = "0rqn5iga1hlv2lm8xzav1zhar46jb4dvx89i6kfv93kb53maxxl2";
         procMacro = true;
         libName = "async_trait";
         authors = [
@@ -989,9 +989,9 @@ rec {
       };
       "cc" = rec {
         crateName = "cc";
-        version = "1.4.1";
+        version = "1.4.3";
         edition = "2021";
-        sha256 = "0dniydgf5lv8dh4mr6n1gvas9albqmp0kyh557wkcij6jacw8rlh";
+        sha256 = "0v9b5arr047vbihfbh3fmbd3aj9vf1i7dbdgfpvlwzynpjvr35ah";
         dependencies = [
           {
             name = "find-msvc-tools";
@@ -1903,7 +1903,7 @@ rec {
         dependencies = [
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
           }
         ];
         features = {
@@ -2794,9 +2794,9 @@ rec {
       };
       "find-msvc-tools" = rec {
         crateName = "find-msvc-tools";
-        version = "0.1.10";
+        version = "0.1.11";
         edition = "2021";
-        sha256 = "1pp1612g5k6im9732g16j6a87czhb35xcyzlrpq2mkgdwrrkbdr6";
+        sha256 = "145qpfb9r4ml2klr8v4byvrkikp61qyiks9n69b8z0vbscbb0pfl";
         libName = "find_msvc_tools";
 
       };
@@ -2923,11 +2923,11 @@ rec {
         };
         resolvedDefaultFeatures = [ "default" "use_std" "with-deprecated" ];
       };
-      "futures 0.3.33" = rec {
+      "futures 0.3.34" = rec {
         crateName = "futures";
-        version = "0.3.33";
+        version = "0.3.34";
         edition = "2018";
-        sha256 = "066j5aqz8an05xh4hn5ljdnjn80z3g335v4grx4gaifr57wg3358";
+        sha256 = "18yhwmbdalhz2z9i1vm10hy2v0cfm82dkgcb6vr2msxazfix4ccs";
         dependencies = [
           {
             name = "futures-channel";
@@ -2987,9 +2987,9 @@ rec {
       };
       "futures-channel" = rec {
         crateName = "futures-channel";
-        version = "0.3.33";
+        version = "0.3.34";
         edition = "2018";
-        sha256 = "1bn5hlhfkl1sgypmiachaqcgwmr6wmjal7dyhfyb1zkazvs90996";
+        sha256 = "1i4kwcanpaphn1ax62ci3nx176kglxqx0gnhzqpqdr1rkpbf7ydi";
         libName = "futures_channel";
         dependencies = [
           {
@@ -3015,9 +3015,9 @@ rec {
       };
       "futures-core" = rec {
         crateName = "futures-core";
-        version = "0.3.33";
+        version = "0.3.34";
         edition = "2018";
-        sha256 = "1iqdbvcdlplfr2g43h7xrfkv2sg5p1a26x8acz1xgxl07i3hrm9c";
+        sha256 = "0pjgv4fx0np6hrs5sz5a2phabwv0z70yr51v03injbi44bjrkmlj";
         libName = "futures_core";
         features = {
           "default" = [ "std" ];
@@ -3028,9 +3028,9 @@ rec {
       };
       "futures-executor" = rec {
         crateName = "futures-executor";
-        version = "0.3.33";
+        version = "0.3.34";
         edition = "2018";
-        sha256 = "0n3lpkmcfrsnh40i4armn040gnqbpd257hz5qs46zipjr6f8fm37";
+        sha256 = "0cjl3y7jgg60wwb96ikxj23r6q91ylvx8v675yychv1w3b7lf6q3";
         libName = "futures_executor";
         dependencies = [
           {
@@ -3058,9 +3058,9 @@ rec {
       };
       "futures-io" = rec {
         crateName = "futures-io";
-        version = "0.3.33";
+        version = "0.3.34";
         edition = "2018";
-        sha256 = "0yjx13qdm9b2p4w00ddw85k6yccnnmqrlrrz8yfmi5jg7jmfqxs5";
+        sha256 = "1v9z6wj92ra18kpv0xig21hgpzrvcwmcr8fszyzh64yyay0zmh2k";
         libName = "futures_io";
         features = {
           "default" = [ "std" ];
@@ -3069,9 +3069,9 @@ rec {
       };
       "futures-macro" = rec {
         crateName = "futures-macro";
-        version = "0.3.33";
+        version = "0.3.34";
         edition = "2018";
-        sha256 = "02xiyd5y1nk9b805aympj4wq2czgvxnhcml9w9xkc665d3g3qv9d";
+        sha256 = "0i0czvcvsqq4hrccibq2f23004si5z34zjwdxfmqhlrmm15nbfcz";
         procMacro = true;
         libName = "futures_macro";
         dependencies = [
@@ -3085,7 +3085,7 @@ rec {
           }
           {
             name = "syn";
-            packageId = "syn 2.0.119";
+            packageId = "syn 3.0.3";
             features = [ "full" ];
           }
         ];
@@ -3093,9 +3093,9 @@ rec {
       };
       "futures-sink" = rec {
         crateName = "futures-sink";
-        version = "0.3.33";
+        version = "0.3.34";
         edition = "2018";
-        sha256 = "01z38z344hpryw84b6r0rbwcb669d8pyvl2szg10aqwx96n1hi73";
+        sha256 = "07cfvrgc3vxk6sw5g8a8dnrm1mzg6d5mwy08ywa1sgyhyxml4i0r";
         libName = "futures_sink";
         features = {
           "default" = [ "std" ];
@@ -3105,9 +3105,9 @@ rec {
       };
       "futures-task" = rec {
         crateName = "futures-task";
-        version = "0.3.33";
+        version = "0.3.34";
         edition = "2018";
-        sha256 = "02f1y1yvjg1cv998zkgl1706pi9y4fyc9045l1hlmyqyhclfscdj";
+        sha256 = "1zfilqs8nwlfqz4prk7ihvpp5avvzins87ibzlxzq5fhs7ipshfd";
         libName = "futures_task";
         features = {
           "default" = [ "std" ];
@@ -3132,9 +3132,9 @@ rec {
       };
       "futures-util" = rec {
         crateName = "futures-util";
-        version = "0.3.33";
+        version = "0.3.34";
         edition = "2018";
-        sha256 = "1anyg40j5www5l22r2jbn1birsafz4q1w9qmcjk4vqzwasi90ym7";
+        sha256 = "1g3r9ghzq7c2fh34lis43i72xavk9p84npgfwgb5vfpqcwjajl0d";
         libName = "futures_util";
         dependencies = [
           {
@@ -3621,9 +3621,9 @@ rec {
       };
       "h2" = rec {
         crateName = "h2";
-        version = "0.4.15";
+        version = "0.4.17";
         edition = "2021";
-        sha256 = "0mgilh1g8gydcchqi6acs5l6j0gwg5jwpa64sj4b3ncb9v497c3c";
+        sha256 = "0jblh2mscahvbz42d1sp5702ib444rcxswm5a3n2g64yydspx1wz";
         authors = [
           "Carl Lerche <me@carllerche.com>"
           "Sean McArthur <sean@seanmonstar.com>"
@@ -3861,9 +3861,9 @@ rec {
       };
       "http-body-util" = rec {
         crateName = "http-body-util";
-        version = "0.1.4";
+        version = "0.1.5";
         edition = "2018";
-        sha256 = "1wizkqx9a75x8v5lm7cawpammz8sfvd7cngnkp34wkcfl3b1zx79";
+        sha256 = "07773iilap808wjp6vywlq15zkgwnswqzrv270zxvg2z9biry5i3";
         libName = "http_body_util";
         authors = [
           "Carl Lerche <me@carllerche.com>"
@@ -4371,9 +4371,9 @@ rec {
       };
       "icu_collections" = rec {
         crateName = "icu_collections";
-        version = "2.2.0";
-        edition = "2021";
-        sha256 = "070r7xd0pynm0hnc1v2jzlbxka6wf50f81wybf9xg0y82v6x3119";
+        version = "2.3.0";
+        edition = "2024";
+        sha256 = "04x59h6vdq0cnpippim1nr471ivlsnnn470sj1d5v864h48d4s7s";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -4421,9 +4421,9 @@ rec {
       };
       "icu_locale_core" = rec {
         crateName = "icu_locale_core";
-        version = "2.2.0";
-        edition = "2021";
-        sha256 = "0a9cmin5w1x3bg941dlmgszn33qgq428k7qiqn5did72ndi9n8cj";
+        version = "2.3.0";
+        edition = "2024";
+        sha256 = "1sqdj16wwl7h9y6r7j394av4kpdb7zryz9h169ffwbm9imc2hvnm";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -4473,9 +4473,9 @@ rec {
       };
       "icu_normalizer" = rec {
         crateName = "icu_normalizer";
-        version = "2.2.0";
-        edition = "2021";
-        sha256 = "1d7krxr0xpc4x9635k1100a24nh0nrc59n65j6yk6gbfkplmwvn5";
+        version = "2.3.0";
+        edition = "2024";
+        sha256 = "0vv43ixk2wmbxrx7kl33cwkhx1wdyb1q3pa18qkyshan4dgwzy8j";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -4527,9 +4527,9 @@ rec {
       };
       "icu_normalizer_data" = rec {
         crateName = "icu_normalizer_data";
-        version = "2.2.0";
-        edition = "2021";
-        sha256 = "0f5d5d5fhhr9937m2z6z38fzh6agf14z24kwlr6lyczafypf0fys";
+        version = "2.3.0";
+        edition = "2024";
+        sha256 = "1811h0ppb7lwq1q2492p5x6lcmlwmhbmkf69fhyvzcz0scgdlqqm";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -4537,13 +4537,18 @@ rec {
       };
       "icu_properties" = rec {
         crateName = "icu_properties";
-        version = "2.2.0";
-        edition = "2021";
-        sha256 = "1pkh3s837808cbwxvfagwc28cvwrz2d9h5rl02jwrhm51ryvdqxy";
+        version = "2.3.0";
+        edition = "2024";
+        sha256 = "0j51hi8qgf0l6a7qzvnwsc61598w2fpnsklicld6ci9immva4z3y";
         authors = [
           "The ICU4X Project Developers"
         ];
         dependencies = [
+          {
+            name = "displaydoc";
+            packageId = "displaydoc";
+            usesDefaultFeatures = false;
+          }
           {
             name = "icu_collections";
             packageId = "icu_collections";
@@ -4585,6 +4590,7 @@ rec {
           "datagen" = [ "serde" "dep:databake" "zerovec/databake" "icu_collections/databake" "icu_locale_core/databake" "zerotrie/databake" "icu_provider/export" ];
           "default" = [ "compiled_data" ];
           "harfbuzz_traits" = [ "dep:harfbuzz-traits" ];
+          "log" = [ "dep:log" ];
           "serde" = [ "dep:serde" "icu_locale_core/serde" "zerovec/serde" "icu_collections/serde" "icu_provider/serde" "zerotrie/serde" ];
           "unicode_bidi" = [ "dep:unicode-bidi" ];
         };
@@ -4592,9 +4598,9 @@ rec {
       };
       "icu_properties_data" = rec {
         crateName = "icu_properties_data";
-        version = "2.2.0";
-        edition = "2021";
-        sha256 = "052awny0qwkbcbpd5jg2cd7vl5ry26pq4hz1nfsgf10c3qhbnawf";
+        version = "2.3.0";
+        edition = "2024";
+        sha256 = "1akw1gp5rcaiz377xzsnkx8f92qax4kh3lfn9y4rcjj6q4wg1475";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -4602,9 +4608,9 @@ rec {
       };
       "icu_provider" = rec {
         crateName = "icu_provider";
-        version = "2.2.0";
-        edition = "2021";
-        sha256 = "08dl8pxbwr8zsz4c5vphqb7xw0hykkznwi4rw7bk6pwb3krlr70k";
+        version = "2.3.0";
+        edition = "2024";
+        sha256 = "0a343jlrb7jlb20xv1airslzv63559wf38jihrx81bba39kyv9wj";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -5103,7 +5109,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
           }
           {
             name = "windows-link";
@@ -5221,9 +5227,9 @@ rec {
       };
       "js-sys" = rec {
         crateName = "js-sys";
-        version = "0.3.103";
+        version = "0.3.104";
         edition = "2021";
-        sha256 = "00lib0b6hqmw56r2hjp7xrv730qacslirbkdlhvmi39zvgy4pd2k";
+        sha256 = "0fjsgady7wbv7bbyy6c8qhrd93bnx11qbl83l1g7bb9a4601030f";
         libName = "js_sys";
         authors = [
           "The wasm-bindgen Developers"
@@ -5283,7 +5289,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
           }
         ];
         devDependencies = [
@@ -5332,7 +5338,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
           }
         ];
 
@@ -5430,8 +5436,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "fb2d86579f4e3df008f78f0e527a012243483a2d";
-          sha256 = "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb";
+          rev = "7b9f9ac9a76fa425ab27f2821377ef86571ca121";
+          sha256 = "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9";
         };
         libName = "k8s_version";
         authors = [
@@ -5609,7 +5615,7 @@ rec {
           }
           {
             name = "futures";
-            packageId = "futures 0.3.33";
+            packageId = "futures 0.3.34";
             optional = true;
             usesDefaultFeatures = false;
             features = [ "std" ];
@@ -5709,7 +5715,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
           }
           {
             name = "tokio";
@@ -5745,7 +5751,7 @@ rec {
         devDependencies = [
           {
             name = "futures";
-            packageId = "futures 0.3.33";
+            packageId = "futures 0.3.34";
             usesDefaultFeatures = false;
             features = [ "async-await" ];
           }
@@ -5875,7 +5881,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
           }
         ];
         devDependencies = [
@@ -5982,7 +5988,7 @@ rec {
           }
           {
             name = "futures";
-            packageId = "futures 0.3.33";
+            packageId = "futures 0.3.34";
             usesDefaultFeatures = false;
             features = [ "async-await" ];
           }
@@ -6027,7 +6033,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
           }
           {
             name = "tokio";
@@ -6206,9 +6212,9 @@ rec {
       };
       "litemap" = rec {
         crateName = "litemap";
-        version = "0.8.2";
+        version = "0.8.3";
         edition = "2021";
-        sha256 = "1w7628bc7wwcxc4n4s5kw0610xk06710nh2hn5kwwk2wa91z9nlj";
+        sha256 = "1bpgpj87560hmckh3875fbahpmfxbk4g8pzns84h3ykf3nfx3na7";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -6526,9 +6532,9 @@ rec {
       };
       "num-integer" = rec {
         crateName = "num-integer";
-        version = "0.1.46";
+        version = "0.1.47";
         edition = "2018";
-        sha256 = "13w5g54a9184cqlbsq80rnxw4jj4s0d8wv75jsq5r2lms8gncsbr";
+        sha256 = "02z1p3azy6p10n99skrab4a6hhfd4amf2i9gm8sxqd1p9dfxkqkw";
         libName = "num_integer";
         authors = [
           "The Rust Project Developers"
@@ -6670,7 +6676,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
             optional = true;
             usesDefaultFeatures = false;
           }
@@ -6840,7 +6846,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
             usesDefaultFeatures = false;
           }
           {
@@ -7047,7 +7053,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
             usesDefaultFeatures = false;
           }
           {
@@ -7348,9 +7354,9 @@ rec {
       };
       "pest" = rec {
         crateName = "pest";
-        version = "2.8.8";
+        version = "2.9.0";
         edition = "2021";
-        sha256 = "18jhl2zpxvl6kikc0jgp7gi7i7cy9s634z5bnvx70w1whjz2ixvx";
+        sha256 = "1kwvhc5hyrfpxpmp0jw0wr891xyjs44mcs2wz68hrl54qw6ac1ss";
         authors = [
           "Dragoș Tiselice <dragostiselice@gmail.com>"
         ];
@@ -7377,9 +7383,9 @@ rec {
       };
       "pest_derive" = rec {
         crateName = "pest_derive";
-        version = "2.8.8";
+        version = "2.9.0";
         edition = "2021";
-        sha256 = "1zcijlfdf6sk2s6l1qnm3j7kj7d4ymqcial8w4p4dcr67gydcbcy";
+        sha256 = "13f8ihi8928s9mc13pcbhxy382kqc89h7i8d7s5mnif8lm23ga5k";
         procMacro = true;
         authors = [
           "Dragoș Tiselice <dragostiselice@gmail.com>"
@@ -7405,9 +7411,9 @@ rec {
       };
       "pest_generator" = rec {
         crateName = "pest_generator";
-        version = "2.8.8";
+        version = "2.9.0";
         edition = "2021";
-        sha256 = "1dkmk6r6bb2hh5wayymfmwd7mswwbyhw12dnx2lrdxdnrw2r4yka";
+        sha256 = "0jihcdnmdban4bqjd02r2wbb79nywj2nhwqyk95hvrixm98k9kg0";
         authors = [
           "Dragoș Tiselice <dragostiselice@gmail.com>"
         ];
@@ -7443,9 +7449,9 @@ rec {
       };
       "pest_meta" = rec {
         crateName = "pest_meta";
-        version = "2.8.8";
+        version = "2.9.0";
         edition = "2021";
-        sha256 = "0z7m54jc3nj3nxbbk4kyjfa06d8s24vhf6krzj2867nyq18x7aw5";
+        sha256 = "15jly0r7r4m15fhm3pg814h65j7dqnqq6k43rvgxfhg29443lkg0";
         authors = [
           "Dragoș Tiselice <dragostiselice@gmail.com>"
         ];
@@ -7576,9 +7582,9 @@ rec {
       };
       "pkg-config" = rec {
         crateName = "pkg-config";
-        version = "0.3.33";
-        edition = "2018";
-        sha256 = "17jnqmcbxsnwhg9gjf0nh6dj5k0x3hgwi3mb9krjnmfa9v435w8r";
+        version = "0.3.34";
+        edition = "2021";
+        sha256 = "0j05h08nzg0q8rf6lzw7nry0b7kn7x97vc9n4hwrl52fqzxn9d7n";
         libName = "pkg_config";
         authors = [
           "Alex Crichton <alex@alexcrichton.com>"
@@ -7587,9 +7593,9 @@ rec {
       };
       "portable-atomic" = rec {
         crateName = "portable-atomic";
-        version = "1.14.0";
+        version = "1.15.0";
         edition = "2018";
-        sha256 = "1hyfma9n2cs2ibazpfwrbv61zwg7cv86g0pr5yjkg07qgr4xa81x";
+        sha256 = "11csag858ndk5w4yz17h91vy53ynh67r2903gwwdn2cnilzbdj05";
         libName = "portable_atomic";
         features = {
           "critical-section" = [ "dep:critical-section" ];
@@ -7620,9 +7626,9 @@ rec {
       };
       "potential_utf" = rec {
         crateName = "potential_utf";
-        version = "0.1.5";
+        version = "0.1.6";
         edition = "2021";
-        sha256 = "0r0518fr32xbkgzqap509s3r60cr0iancsg9j1jgf37cyz7b20q1";
+        sha256 = "0qbndl2fpphq7mph41m11vaixs05xrh1s451wxlgap4fdnybjgnq";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -8133,9 +8139,9 @@ rec {
       };
       "ref-cast" = rec {
         crateName = "ref-cast";
-        version = "1.0.26";
+        version = "1.0.27";
         edition = "2021";
-        sha256 = "0vdra0766jcc2czzqwhql41kkfyajdnai1pbkjxbq8vr7mvqyvi1";
+        sha256 = "1hv5sf0j7b65gz2g57c3wp0fzr5r3807dywf6fap455lwjs0yi3y";
         libName = "ref_cast";
         authors = [
           "David Tolnay <dtolnay@gmail.com>"
@@ -8150,9 +8156,9 @@ rec {
       };
       "ref-cast-impl" = rec {
         crateName = "ref-cast-impl";
-        version = "1.0.26";
+        version = "1.0.27";
         edition = "2021";
-        sha256 = "0g70ff9an5i97cw9kijgzqrqydz7smcfic2zyydddizfbxl874ic";
+        sha256 = "0fnzgkvddgl9xs3884x5ypi9rd0dgc1p5vd1k4b74lw49ybdiv4j";
         procMacro = true;
         libName = "ref_cast_impl";
         authors = [
@@ -9090,9 +9096,9 @@ rec {
       };
       "rustls-webpki" = rec {
         crateName = "rustls-webpki";
-        version = "0.103.13";
+        version = "0.103.14";
         edition = "2021";
-        sha256 = "0vkm7z9pnxz5qz66p2kmyy2pwx0g4jnsbqk5xzfhs4czcjl2ki31";
+        sha256 = "0njk28gvbqrsfg1b5r35y4f80n37kcjylj72fpc0k0g60n3529q5";
         libName = "webpki";
         dependencies = [
           {
@@ -9116,7 +9122,7 @@ rec {
           "alloc" = [ "ring?/alloc" "pki-types/alloc" ];
           "aws-lc-rs" = [ "dep:aws-lc-rs" "aws-lc-rs/aws-lc-sys" "aws-lc-rs/prebuilt-nasm" ];
           "aws-lc-rs-fips" = [ "dep:aws-lc-rs" "aws-lc-rs/fips" ];
-          "aws-lc-rs-unstable" = [ "aws-lc-rs" "aws-lc-rs/unstable" ];
+          "aws-lc-rs-unstable" = [ "aws-lc-rs" ];
           "default" = [ "std" ];
           "ring" = [ "dep:ring" ];
           "std" = [ "alloc" "pki-types/std" ];
@@ -10328,8 +10334,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "fb2d86579f4e3df008f78f0e527a012243483a2d";
-          sha256 = "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb";
+          rev = "7b9f9ac9a76fa425ab27f2821377ef86571ca121";
+          sha256 = "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9";
         };
         libName = "stackable_certs";
         authors = [
@@ -10426,13 +10432,13 @@ rec {
       };
       "stackable-operator" = rec {
         crateName = "stackable-operator";
-        version = "0.115.0";
+        version = "0.116.0";
         edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "fb2d86579f4e3df008f78f0e527a012243483a2d";
-          sha256 = "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb";
+          rev = "7b9f9ac9a76fa425ab27f2821377ef86571ca121";
+          sha256 = "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9";
         };
         libName = "stackable_operator";
         authors = [
@@ -10472,7 +10478,7 @@ rec {
           }
           {
             name = "futures";
-            packageId = "futures 0.3.33";
+            packageId = "futures 0.3.34";
           }
           {
             name = "http";
@@ -10612,7 +10618,8 @@ rec {
           "client-feature-gates" = [ "dep:winnow" ];
           "crds" = [ "dep:stackable-versioned" ];
           "default" = [ "crds" ];
-          "full" = [ "client-feature-gates" "crds" "certs" "test-support" "time" "webhook" "kube-ws" ];
+          "full" = [ "client-feature-gates" "crds" "certs" "test-support" "time" "webhook" "kube-ws" "kube-cel" ];
+          "kube-cel" = [ "kube/cel" ];
           "kube-ws" = [ "kube/ws" ];
           "time" = [ "stackable-shared/time" ];
           "webhook" = [ "dep:stackable-webhook" ];
@@ -10626,8 +10633,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "fb2d86579f4e3df008f78f0e527a012243483a2d";
-          sha256 = "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb";
+          rev = "7b9f9ac9a76fa425ab27f2821377ef86571ca121";
+          sha256 = "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9";
         };
         procMacro = true;
         libName = "stackable_operator_derive";
@@ -10661,8 +10668,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "fb2d86579f4e3df008f78f0e527a012243483a2d";
-          sha256 = "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb";
+          rev = "7b9f9ac9a76fa425ab27f2821377ef86571ca121";
+          sha256 = "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9";
         };
         libName = "stackable_shared";
         authors = [
@@ -10742,8 +10749,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "fb2d86579f4e3df008f78f0e527a012243483a2d";
-          sha256 = "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb";
+          rev = "7b9f9ac9a76fa425ab27f2821377ef86571ca121";
+          sha256 = "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9";
         };
         libName = "stackable_telemetry";
         authors = [
@@ -10879,7 +10886,7 @@ rec {
           }
           {
             name = "futures";
-            packageId = "futures 0.3.33";
+            packageId = "futures 0.3.34";
             features = [ "compat" ];
           }
           {
@@ -10951,8 +10958,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "fb2d86579f4e3df008f78f0e527a012243483a2d";
-          sha256 = "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb";
+          rev = "7b9f9ac9a76fa425ab27f2821377ef86571ca121";
+          sha256 = "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9";
         };
         libName = "stackable_versioned";
         authors = [
@@ -11001,8 +11008,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "fb2d86579f4e3df008f78f0e527a012243483a2d";
-          sha256 = "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb";
+          rev = "7b9f9ac9a76fa425ab27f2821377ef86571ca121";
+          sha256 = "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9";
         };
         procMacro = true;
         libName = "stackable_versioned_macros";
@@ -11069,8 +11076,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "fb2d86579f4e3df008f78f0e527a012243483a2d";
-          sha256 = "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb";
+          rev = "7b9f9ac9a76fa425ab27f2821377ef86571ca121";
+          sha256 = "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9";
         };
         libName = "stackable_webhook";
         authors = [
@@ -11452,18 +11459,18 @@ rec {
         ];
 
       };
-      "thiserror 2.0.19" = rec {
+      "thiserror 2.0.20" = rec {
         crateName = "thiserror";
-        version = "2.0.19";
+        version = "2.0.20";
         edition = "2021";
-        sha256 = "1ngwxsjsa64v1n7vb90h2b0i3fqk1piwaf0z6fqdacqfhjc3b909";
+        sha256 = "0kxs6p295jffxhzaxpxv1dwaaf5iqlm6sx8h0djp6ancbxgj71pc";
         authors = [
           "David Tolnay <dtolnay@gmail.com>"
         ];
         dependencies = [
           {
             name = "thiserror-impl";
-            packageId = "thiserror-impl 2.0.19";
+            packageId = "thiserror-impl 2.0.20";
           }
         ];
         features = {
@@ -11497,11 +11504,11 @@ rec {
         ];
 
       };
-      "thiserror-impl 2.0.19" = rec {
+      "thiserror-impl 2.0.20" = rec {
         crateName = "thiserror-impl";
-        version = "2.0.19";
+        version = "2.0.20";
         edition = "2021";
-        sha256 = "1ka10pqy1g8zy5al9m8yadg30jp8hx0q80j8awmd8131yw6gxjs3";
+        sha256 = "1bwjc94gi0xn5jz26h1a8bjj1wdkvvr6jifamyc4mp9n28zcs15w";
         procMacro = true;
         libName = "thiserror_impl";
         authors = [
@@ -11650,9 +11657,9 @@ rec {
       };
       "tinystr" = rec {
         crateName = "tinystr";
-        version = "0.8.3";
+        version = "0.8.4";
         edition = "2021";
-        sha256 = "0vfr8x285w6zsqhna0a9jyhylwiafb2kc8pj2qaqaahw48236cn8";
+        sha256 = "0hzncw8rgk4syla79qscfml46jm7ll1zdp7kdacc42cj8n8prqmi";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -12733,7 +12740,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
           }
           {
             name = "time";
@@ -13268,9 +13275,9 @@ rec {
       };
       "uuid" = rec {
         crateName = "uuid";
-        version = "1.24.0";
+        version = "1.24.1";
         edition = "2021";
-        sha256 = "0faj5x0zgri8m3i8dv9qgyhiwqwdyhbl2g351cp3iin4ynk26fdz";
+        sha256 = "1n8b7fg7dbx6ws64387l2i0qq900rw9b7qax63acdh37sczw1vrc";
         authors = [
           "Ashley Mannix<ashleymannix@live.com.au>"
           "Dylan DPC<dylan.dpc@gmail.com>"
@@ -13434,9 +13441,9 @@ rec {
       };
       "wasm-bindgen" = rec {
         crateName = "wasm-bindgen";
-        version = "0.2.126";
+        version = "0.2.127";
         edition = "2021";
-        sha256 = "197rma4qg1kb8l4bl7857pgszzval8s1w740g9myyjh92467q1jb";
+        sha256 = "0w6fa1mkbb6qlkffgy4qaz0hdf496zbjkyiyvs4lvmpd8xbr6w0v";
         libName = "wasm_bindgen";
         authors = [
           "The wasm-bindgen Developers"
@@ -13485,9 +13492,9 @@ rec {
       };
       "wasm-bindgen-futures" = rec {
         crateName = "wasm-bindgen-futures";
-        version = "0.4.76";
+        version = "0.4.77";
         edition = "2021";
-        sha256 = "0799v92cpaprapnmpaflc51sdnz362q2fsjdqnwiq8ij1wsg2bf6";
+        sha256 = "0l3r8m335kb2p8yj65kb0biwlypcx3ay4g750hafkl13rkapfxvb";
         libName = "wasm_bindgen_futures";
         authors = [
           "The wasm-bindgen Developers"
@@ -13513,9 +13520,9 @@ rec {
       };
       "wasm-bindgen-macro" = rec {
         crateName = "wasm-bindgen-macro";
-        version = "0.2.126";
+        version = "0.2.127";
         edition = "2021";
-        sha256 = "1cda6wl5zyiy7777cfgrix7fhpaqba55l5zpqj4zig7ng7jyaz0n";
+        sha256 = "1hcvlb6bv771fvgifd367wd0cm4giyar8fq5i4h705vj7y7myxvp";
         procMacro = true;
         libName = "wasm_bindgen_macro";
         authors = [
@@ -13537,9 +13544,9 @@ rec {
       };
       "wasm-bindgen-macro-support" = rec {
         crateName = "wasm-bindgen-macro-support";
-        version = "0.2.126";
+        version = "0.2.127";
         edition = "2021";
-        sha256 = "03iq412frl2py55skwb3ya08xha0cf6q22zr5kqlwbr675w7r6gk";
+        sha256 = "112j4d7dv8y2sk9yy9czrl9fpjx9388ywnn7icdv2bywazw367g1";
         libName = "wasm_bindgen_macro_support";
         authors = [
           "The wasm-bindgen Developers"
@@ -13573,10 +13580,10 @@ rec {
       };
       "wasm-bindgen-shared" = rec {
         crateName = "wasm-bindgen-shared";
-        version = "0.2.126";
+        version = "0.2.127";
         edition = "2021";
         links = "wasm_bindgen";
-        sha256 = "097a3kbjls447s1lwr41l21x5crrh5vq3h6zsxccz7slrjq4q6yw";
+        sha256 = "1gywp6xv8a27fvm3ga9xby93xyic3hc2s626b9z9rw2xqny4vxky";
         libName = "wasm_bindgen_shared";
         authors = [
           "The wasm-bindgen Developers"
@@ -13591,9 +13598,9 @@ rec {
       };
       "web-sys" = rec {
         crateName = "web-sys";
-        version = "0.3.103";
+        version = "0.3.104";
         edition = "2021";
-        sha256 = "0hb1zdnrp99p5r5q66jagsddmwha460yv2wklvzrzk0b3jvdq8l6";
+        sha256 = "0c0acbvaqzqf21q5vdff2g74fvb7afi91xjplmclybq4d24k6df4";
         libName = "web_sys";
         authors = [
           "The wasm-bindgen Developers"
@@ -13849,6 +13856,10 @@ rec {
           "MouseEvent" = [ "Event" "UiEvent" ];
           "MouseScrollEvent" = [ "Event" "MouseEvent" "UiEvent" ];
           "MutationEvent" = [ "Event" ];
+          "NavigateEvent" = [ "Event" ];
+          "Navigation" = [ "EventTarget" ];
+          "NavigationCurrentEntryChangeEvent" = [ "Event" ];
+          "NavigationHistoryEntry" = [ "EventTarget" ];
           "NetworkInformation" = [ "EventTarget" ];
           "Node" = [ "EventTarget" ];
           "Notification" = [ "EventTarget" ];
@@ -14971,9 +14982,9 @@ rec {
       };
       "writeable" = rec {
         crateName = "writeable";
-        version = "0.6.3";
+        version = "0.6.4";
         edition = "2021";
-        sha256 = "1i54d13h9bpap2hf13xcry1s4lxh7ap3923g8f3c0grd7c9fbyhz";
+        sha256 = "1p3r4s4wbf3dksfpj3xyrn7id5p0f7r74mj6qx6ngjfd6cm2vn1s";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -15283,9 +15294,9 @@ rec {
       };
       "zerotrie" = rec {
         crateName = "zerotrie";
-        version = "0.2.4";
+        version = "0.2.5";
         edition = "2021";
-        sha256 = "1gr0pkcn3qsr6in6iixqyp0vbzwf2j1jzyvh7yl2yydh3p9m548g";
+        sha256 = "0gss16krjzk22m57dz5hkdjg99ibj6pa41qr68na7w1jpp1nk8jf";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -15323,9 +15334,9 @@ rec {
       };
       "zerovec" = rec {
         crateName = "zerovec";
-        version = "0.11.6";
+        version = "0.11.8";
         edition = "2021";
-        sha256 = "0fdjsy6b31q9i0d73sl7xjd12xadbwi45lkpfgqnmasrqg5i3ych";
+        sha256 = "1n3xlvyba8riys9s8awy4xp533phqycr78nbsmvdkh86g3hn815v";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -15369,9 +15380,9 @@ rec {
       };
       "zerovec-derive" = rec {
         crateName = "zerovec-derive";
-        version = "0.11.3";
+        version = "0.11.5";
         edition = "2021";
-        sha256 = "0m85qj92mmfvhjra6ziqky5b1p4kcmp5069k7kfadp5hr8jw8pb2";
+        sha256 = "1a8pz516ddcgxvxq3j1xgprac5wnprlrbyzsgzarj0423la2l8cz";
         procMacro = true;
         libName = "zerovec_derive";
         authors = [
@@ -15388,7 +15399,7 @@ rec {
           }
           {
             name = "syn";
-            packageId = "syn 2.0.119";
+            packageId = "syn 3.0.3";
             features = [ "extra-traits" ];
           }
         ];

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2024"
 repository = "https://github.com/stackabletech/trino-operator"
 
 [workspace.dependencies]
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.115.0", features = ["webhook"] }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.116.0", features = ["webhook"] }
 
 anyhow = "1.0"
 async-trait = "0.1"

--- a/crate-hashes.json
+++ b/crate-hashes.json
@@ -1,11 +1,11 @@
 {
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#k8s-version@0.1.3": "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#stackable-certs@0.4.1": "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#stackable-operator-derive@0.3.1": "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#stackable-operator@0.115.0": "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#stackable-shared@0.1.2": "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#stackable-telemetry@0.6.5": "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#stackable-versioned-macros@0.11.1": "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#stackable-versioned@0.11.1": "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#stackable-webhook@0.9.2": "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb"
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#k8s-version@0.1.3": "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#stackable-certs@0.4.1": "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#stackable-operator-derive@0.3.1": "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#stackable-operator@0.116.0": "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#stackable-shared@0.1.2": "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#stackable-telemetry@0.6.5": "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#stackable-versioned-macros@0.11.1": "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#stackable-versioned@0.11.1": "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#stackable-webhook@0.9.2": "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9"
 }

--- a/extra/crds.yaml
+++ b/extra/crds.yaml
@@ -1484,7 +1484,8 @@ spec:
                     default: {}
                     description: |-
                       `envOverrides` configure environment variables to be set in the Pods.
-                      It is a map from strings to strings - environment variables and the value to set.
+                      It is a map from environment variable names to their values. The names are validated to be
+                      valid environment variable names.
                       Read the
                       [environment variable overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#env-overrides)
                       for more information and consult the operator specific usage guide to find out about
@@ -2092,7 +2093,8 @@ spec:
                           default: {}
                           description: |-
                             `envOverrides` configure environment variables to be set in the Pods.
-                            It is a map from strings to strings - environment variables and the value to set.
+                            It is a map from environment variable names to their values. The names are validated to be
+                            valid environment variable names.
                             Read the
                             [environment variable overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#env-overrides)
                             for more information and consult the operator specific usage guide to find out about
@@ -2763,7 +2765,8 @@ spec:
                     default: {}
                     description: |-
                       `envOverrides` configure environment variables to be set in the Pods.
-                      It is a map from strings to strings - environment variables and the value to set.
+                      It is a map from environment variable names to their values. The names are validated to be
+                      valid environment variable names.
                       Read the
                       [environment variable overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#env-overrides)
                       for more information and consult the operator specific usage guide to find out about
@@ -3363,7 +3366,8 @@ spec:
                           default: {}
                           description: |-
                             `envOverrides` configure environment variables to be set in the Pods.
-                            It is a map from strings to strings - environment variables and the value to set.
+                            It is a map from environment variable names to their values. The names are validated to be
+                            valid environment variable names.
                             Read the
                             [environment variable overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#env-overrides)
                             for more information and consult the operator specific usage guide to find out about

--- a/rust/operator-binary/src/authentication/password/file.rs
+++ b/rust/operator-binary/src/authentication/password/file.rs
@@ -226,6 +226,12 @@ mod tests {
     const AUTH_CLASS_NAME: &str = "test-auth";
 
     #[test]
+    fn test_constants() {
+        // Test that dereferencing the constant does not panic.
+        let _ = *PASSWORD_DB_VOLUME_NAME;
+    }
+
+    #[test]
     fn test_file_authenticator() {
         let authenticator = FileAuthenticator::new(
             AUTH_CLASS_NAME.to_string(),

--- a/rust/operator-binary/src/authorization/opa.rs
+++ b/rust/operator-binary/src/authorization/opa.rs
@@ -155,6 +155,12 @@ impl TrinoOpaConfig {
 mod tests {
     use super::*;
 
+    #[test]
+    fn test_constants() {
+        // Test that dereferencing the constant does not panic.
+        let _ = *OPA_TLS_VOLUME_NAME;
+    }
+
     fn minimal_opa() -> TrinoOpaConfig {
         TrinoOpaConfig {
             non_batched_connection_string: "http://opa/allow".to_string(),

--- a/rust/operator-binary/src/config/client_protocol.rs
+++ b/rust/operator-binary/src/config/client_protocol.rs
@@ -105,7 +105,7 @@ impl ResolvedClientProtocolConfig {
                     ("protocol.spooling.enabled".to_string(), "true".to_string()),
                     (
                         "protocol.spooling.shared-secret-key".to_string(),
-                        format!("${{ENV:{ENV_SPOOLING_SECRET}}}"),
+                        format!("${{ENV:{env_var}}}", env_var = ENV_SPOOLING_SECRET.as_ref()),
                     ),
                 ]);
             }

--- a/rust/operator-binary/src/controller/apply.rs
+++ b/rust/operator-binary/src/controller/apply.rs
@@ -17,7 +17,7 @@ use crate::{
         Applied, KubernetesResources, Prepared, ValidatedCluster, shared_internal_secret_name,
         shared_spooling_secret_name,
     },
-    crd::{ENV_INTERNAL_SECRET, ENV_SPOOLING_SECRET},
+    crd::{INTERNAL_SECRET_SECRET_KEY, SPOOLING_SECRET_SECRET_KEY},
     trino_controller::{CONTROLLER_NAME, OPERATOR_NAME, PRODUCT_NAME},
 };
 
@@ -160,8 +160,8 @@ impl<'a> Applier<'a> {
 /// invalidate all running queries).
 pub async fn ensure_random_secrets(client: &Client, cluster: &ValidatedCluster) -> Result<()> {
     random_secret_creation::create_random_secret_if_not_exists(
-        &shared_internal_secret_name(&cluster.name),
-        ENV_INTERNAL_SECRET,
+        shared_internal_secret_name(&cluster.name).as_ref(),
+        INTERNAL_SECRET_SECRET_KEY.as_ref(),
         512,
         cluster,
         client,
@@ -172,8 +172,8 @@ pub async fn ensure_random_secrets(client: &Client, cluster: &ValidatedCluster) 
     // This secret is created even if spooling is not configured.
     // Trino currently requires the secret to be exactly 256 bits long.
     random_secret_creation::create_random_secret_if_not_exists(
-        &shared_spooling_secret_name(&cluster.name),
-        ENV_SPOOLING_SECRET,
+        shared_spooling_secret_name(&cluster.name).as_ref(),
+        SPOOLING_SECRET_SECRET_KEY.as_ref(),
         32,
         cluster,
         client,

--- a/rust/operator-binary/src/controller/apply.rs
+++ b/rust/operator-binary/src/controller/apply.rs
@@ -14,10 +14,11 @@ use strum::{EnumDiscriminants, IntoStaticStr};
 
 use crate::{
     controller::{
-        Applied, KubernetesResources, Prepared, ValidatedCluster, controller_name, operator_name,
-        product_name, shared_internal_secret_name, shared_spooling_secret_name,
+        Applied, KubernetesResources, Prepared, ValidatedCluster, shared_internal_secret_name,
+        shared_spooling_secret_name,
     },
     crd::{ENV_INTERNAL_SECRET, ENV_SPOOLING_SECRET},
+    trino_controller::{CONTROLLER_NAME, OPERATOR_NAME, PRODUCT_NAME},
 };
 
 #[derive(Snafu, Debug, EnumDiscriminants)]
@@ -63,9 +64,9 @@ impl<'a> Applier<'a> {
         object_overrides: &'a ObjectOverrides,
     ) -> Applier<'a> {
         let cluster_resources = cluster_resources_new(
-            &product_name(),
-            &operator_name(),
-            &controller_name(),
+            &PRODUCT_NAME,
+            &OPERATOR_NAME,
+            &CONTROLLER_NAME,
             &cluster.name,
             &cluster.namespace,
             &cluster.uid,

--- a/rust/operator-binary/src/controller/build.rs
+++ b/rust/operator-binary/src/controller/build.rs
@@ -7,22 +7,30 @@ use stackable_operator::{
     builder::meta::ObjectMetaBuilder,
     kvp::Labels,
     utils::cluster_info::KubernetesClusterInfo,
-    v2::{builder::meta::ownerreference_from_resource, types::operator::RoleGroupName},
+    v2::{
+        builder::meta::ownerreference_from_resource,
+        kvp::label,
+        types::operator::{RoleGroupName, RoleName},
+    },
 };
 
-use crate::controller::{
-    KubernetesResources, Prepared, ValidatedCluster,
-    build::resource::{
-        config_map,
-        listener::{build_group_listener, group_listener_name},
-        pdb::build_pdb,
-        rbac::{build_role_binding, build_service_account},
-        service::{
-            build_rolegroup_headless_service, build_rolegroup_metrics_service,
-            headless_service_ports,
+use crate::{
+    controller::{
+        KubernetesResources, Prepared, ValidatedCluster,
+        build::resource::{
+            config_map,
+            listener::{build_group_listener, group_listener_name},
+            pdb::build_pdb,
+            rbac::{build_role_binding, build_service_account},
+            service::{
+                build_rolegroup_headless_service, build_rolegroup_metrics_service,
+                headless_service_ports,
+            },
+            statefulset,
         },
-        statefulset,
     },
+    crd::TrinoRole,
+    trino_controller::{CONTROLLER_NAME, OPERATOR_NAME, PRODUCT_NAME},
 };
 
 pub mod command;
@@ -68,14 +76,12 @@ pub fn build(
 
     for (role, role_group_configs) in &cluster.role_group_configs {
         for (role_group_name, role_group_config) in role_group_configs {
-            let recommended_labels = cluster.recommended_labels(role, role_group_name);
-            let selector = cluster.role_group_selector(role, role_group_name);
+            let selector = role_group_selector(cluster, role, role_group_name);
 
             services.push(build_rolegroup_headless_service(
                 cluster,
                 role,
                 role_group_name,
-                &recommended_labels,
                 selector.clone().into(),
                 headless_service_ports(cluster),
             ));
@@ -83,7 +89,6 @@ pub fn build(
                 cluster,
                 role,
                 role_group_name,
-                &recommended_labels,
                 selector.into(),
             ));
             config_maps.push(
@@ -92,22 +97,16 @@ pub fn build(
                     role,
                     role_group_name,
                     cluster_info,
-                    &recommended_labels,
                 )
                 .context(ConfigMapSnafu {
                     role_group: role_group_name.clone(),
                 })?,
             );
             config_maps.push(
-                config_map::build_rolegroup_catalog_config_map(
-                    cluster,
-                    role,
-                    role_group_name,
-                    &recommended_labels,
-                )
-                .context(ConfigMapSnafu {
-                    role_group: role_group_name.clone(),
-                })?,
+                config_map::build_rolegroup_catalog_config_map(cluster, role, role_group_name)
+                    .context(ConfigMapSnafu {
+                        role_group: role_group_name.clone(),
+                    })?,
             );
             stateful_sets.push(
                 statefulset::build_rolegroup_statefulset(
@@ -131,7 +130,8 @@ pub fn build(
         {
             listeners.push(build_group_listener(
                 cluster,
-                cluster.recommended_labels(role, &PLACEHOLDER_LISTENER_ROLE_GROUP),
+                role,
+                &PLACEHOLDER_LISTENER_ROLE_GROUP,
                 listener_class,
                 listener_group_name,
             ));
@@ -152,23 +152,79 @@ pub fn build(
     })
 }
 
-/// Returns an [`ObjectMetaBuilder`] pre-filled with the cluster's namespace, an owner
-/// reference back to the cluster, the resource `name` and the given `recommended_labels`.
+/// Returns an [`ObjectMetaBuilder`] pre-filled with the namespace, an owner reference back to
+/// the cluster, and the recommended labels for a resource named `name` in `role`/
+/// `role_group_name`.
 ///
-/// Consolidates the metadata chain repeated by the child-resource builders. Call sites that
-/// need extra labels/annotations chain them onto the returned builder.
+/// Consolidates the metadata chain repeated by the role-group child-resource builders. Call
+/// sites that need extra labels/annotations chain them onto the returned builder.
 pub(crate) fn object_meta(
-    cluster: &ValidatedCluster,
+    validated: &ValidatedCluster,
     name: impl Into<String>,
-    recommended_labels: Labels,
+    role: &TrinoRole,
+    role_group_name: &RoleGroupName,
 ) -> ObjectMetaBuilder {
     let mut builder = ObjectMetaBuilder::new();
     builder
-        .name_and_namespace(cluster)
+        .name_and_namespace(validated)
         .name(name)
-        .ownerreference(ownerreference_from_resource(cluster, None, Some(true)))
-        .with_labels(recommended_labels);
+        .ownerreference(ownerreference_from_resource(validated, None, Some(true)))
+        .with_labels(recommended_labels_for_role_group_resources(
+            validated,
+            role,
+            role_group_name,
+        ));
     builder
+}
+
+pub(crate) fn recommended_labels_for_cluster_resources(cluster: &ValidatedCluster) -> Labels {
+    label::recommended_labels_for_cluster_resources(
+        &cluster.name,
+        &PRODUCT_NAME,
+        &cluster.product_version,
+        &OPERATOR_NAME,
+        &CONTROLLER_NAME,
+    )
+}
+
+pub(crate) fn recommended_labels_for_role_group_resources(
+    cluster: &ValidatedCluster,
+    role_name: &RoleName,
+    role_group_name: &RoleGroupName,
+) -> Labels {
+    label::recommended_labels_for_role_group_resources(
+        &cluster.name,
+        &PRODUCT_NAME,
+        &cluster.product_version,
+        &OPERATOR_NAME,
+        &CONTROLLER_NAME,
+        role_name,
+        role_group_name,
+    )
+}
+
+pub(crate) fn recommended_labels_for_unversioned_role_group_resources(
+    cluster: &ValidatedCluster,
+    role_name: &RoleName,
+    role_group_name: &RoleGroupName,
+) -> Labels {
+    label::recommended_labels_for_unversioned_role_group_resources(
+        &cluster.name,
+        &PRODUCT_NAME,
+        &OPERATOR_NAME,
+        &CONTROLLER_NAME,
+        role_name,
+        role_group_name,
+    )
+}
+
+/// Selector labels matching the pods of a role group.
+pub(crate) fn role_group_selector(
+    cluster: &ValidatedCluster,
+    role_name: &RoleName,
+    role_group_name: &RoleGroupName,
+) -> Labels {
+    label::role_group_selector(&cluster.name, &PRODUCT_NAME, role_name, role_group_name)
 }
 
 #[cfg(test)]

--- a/rust/operator-binary/src/controller/build.rs
+++ b/rust/operator-binary/src/controller/build.rs
@@ -29,7 +29,6 @@ use crate::{
             statefulset,
         },
     },
-    crd::TrinoRole,
     trino_controller::{CONTROLLER_NAME, OPERATOR_NAME, PRODUCT_NAME},
 };
 
@@ -153,27 +152,22 @@ pub fn build(
 }
 
 /// Returns an [`ObjectMetaBuilder`] pre-filled with the namespace, an owner reference back to
-/// the cluster, and the recommended labels for a resource named `name` in `role`/
-/// `role_group_name`.
+/// the cluster, the given `name`, and the given `labels` (usually one of the recommended label
+/// sets built by the functions below).
 ///
-/// Consolidates the metadata chain repeated by the role-group child-resource builders. Call
-/// sites that need extra labels/annotations chain them onto the returned builder.
+/// Consolidates the metadata chain repeated by the child-resource builders. Call sites that
+/// need extra labels/annotations chain them onto the returned builder.
 pub(crate) fn object_meta(
     validated: &ValidatedCluster,
     name: impl Into<String>,
-    role: &TrinoRole,
-    role_group_name: &RoleGroupName,
+    labels: Labels,
 ) -> ObjectMetaBuilder {
     let mut builder = ObjectMetaBuilder::new();
     builder
         .name_and_namespace(validated)
         .name(name)
         .ownerreference(ownerreference_from_resource(validated, None, Some(true)))
-        .with_labels(recommended_labels_for_role_group_resources(
-            validated,
-            role,
-            role_group_name,
-        ));
+        .with_labels(labels);
     builder
 }
 

--- a/rust/operator-binary/src/controller/build.rs
+++ b/rust/operator-binary/src/controller/build.rs
@@ -1,6 +1,6 @@
 //! Builders that turn a `ValidatedCluster` into Kubernetes resource contents.
 
-use std::{marker::PhantomData, str::FromStr};
+use std::marker::PhantomData;
 
 use snafu::{ResultExt, Snafu};
 use stackable_operator::{
@@ -37,11 +37,6 @@ pub mod graceful_shutdown;
 pub mod ports;
 pub mod properties;
 pub mod resource;
-
-// Placeholder role-group name used for the recommended labels of a role's group listener.
-// The group listener is owned by the role (not a single role-group), so there is no real
-// role-group to attribute it to.
-stackable_operator::constant!(PLACEHOLDER_LISTENER_ROLE_GROUP: RoleGroupName = "none");
 
 #[derive(Snafu, Debug)]
 pub enum Error {
@@ -130,7 +125,6 @@ pub fn build(
             listeners.push(build_group_listener(
                 cluster,
                 role,
-                &PLACEHOLDER_LISTENER_ROLE_GROUP,
                 listener_class,
                 listener_group_name,
             ));
@@ -178,6 +172,20 @@ pub(crate) fn recommended_labels_for_cluster_resources(cluster: &ValidatedCluste
         &cluster.product_version,
         &OPERATOR_NAME,
         &CONTROLLER_NAME,
+    )
+}
+
+pub(crate) fn recommended_labels_for_role_resources(
+    cluster: &ValidatedCluster,
+    role_name: &RoleName,
+) -> Labels {
+    label::recommended_labels_for_role_resources(
+        &cluster.name,
+        &PRODUCT_NAME,
+        &cluster.product_version,
+        &OPERATOR_NAME,
+        &CONTROLLER_NAME,
+        role_name,
     )
 }
 

--- a/rust/operator-binary/src/controller/build/properties/config_properties.rs
+++ b/rust/operator-binary/src/controller/build/properties/config_properties.rs
@@ -131,7 +131,7 @@ pub fn build(
     props.insert(HTTP_SERVER_LOG_ENABLED.to_string(), "false".to_string());
     props.insert(
         INTERNAL_COMMUNICATION_SHARED_SECRET.to_string(),
-        format!("${{ENV:{ENV_INTERNAL_SECRET}}}"),
+        format!("${{ENV:{env_var}}}", env_var = ENV_INTERNAL_SECRET.as_ref()),
     );
 
     // TLS gating, including the authentication-requires-TLS check.

--- a/rust/operator-binary/src/controller/build/resource/config_map.rs
+++ b/rust/operator-binary/src/controller/build/resource/config_map.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use snafu::{OptionExt, ResultExt, Snafu};
 use stackable_operator::{
-    builder::configmap::ConfigMapBuilder, k8s_openapi::api::core::v1::ConfigMap, kvp::Labels,
+    builder::configmap::ConfigMapBuilder, k8s_openapi::api::core::v1::ConfigMap,
     product_logging::framework::VECTOR_CONFIG_FILE, utils::cluster_info::KubernetesClusterInfo,
     v2::config_file_writer::to_java_properties_string,
 };
@@ -59,7 +59,6 @@ pub fn build_rolegroup_config_map(
     role: &TrinoRole,
     role_group_name: &RoleGroupName,
     cluster_info: &KubernetesClusterInfo,
-    recommended_labels: &Labels,
 ) -> Result<ConfigMap> {
     let role_group_configs =
         cluster
@@ -184,7 +183,7 @@ pub fn build_rolegroup_config_map(
     }
 
     ConfigMapBuilder::new()
-        .metadata(object_meta(cluster, &config_map_name, recommended_labels.clone()).build())
+        .metadata(object_meta(cluster, &config_map_name, role, role_group_name).build())
         .data(data)
         .build()
         .with_context(|_| AssembleSnafu {
@@ -198,18 +197,10 @@ pub fn build_rolegroup_catalog_config_map(
     cluster: &ValidatedCluster,
     role: &TrinoRole,
     role_group_name: &RoleGroupName,
-    recommended_labels: &Labels,
 ) -> Result<ConfigMap> {
     let catalog_config_map_name = cluster.role_group_catalog_config_map_name(role, role_group_name);
     ConfigMapBuilder::new()
-        .metadata(
-            object_meta(
-                cluster,
-                &catalog_config_map_name,
-                recommended_labels.clone(),
-            )
-            .build(),
-        )
+        .metadata(object_meta(cluster, &catalog_config_map_name, role, role_group_name).build())
         .data(
             cluster
                 .cluster_config

--- a/rust/operator-binary/src/controller/build/resource/config_map.rs
+++ b/rust/operator-binary/src/controller/build/resource/config_map.rs
@@ -20,6 +20,7 @@ use crate::{
                 exchange_manager_properties, log_properties, node_properties, product_logging,
                 security_properties, spooling_manager_properties,
             },
+            recommended_labels_for_role_group_resources,
         },
     },
     crd::TrinoRole,
@@ -183,7 +184,14 @@ pub fn build_rolegroup_config_map(
     }
 
     ConfigMapBuilder::new()
-        .metadata(object_meta(cluster, &config_map_name, role, role_group_name).build())
+        .metadata(
+            object_meta(
+                cluster,
+                &config_map_name,
+                recommended_labels_for_role_group_resources(cluster, role, role_group_name),
+            )
+            .build(),
+        )
         .data(data)
         .build()
         .with_context(|_| AssembleSnafu {
@@ -200,7 +208,14 @@ pub fn build_rolegroup_catalog_config_map(
 ) -> Result<ConfigMap> {
     let catalog_config_map_name = cluster.role_group_catalog_config_map_name(role, role_group_name);
     ConfigMapBuilder::new()
-        .metadata(object_meta(cluster, &catalog_config_map_name, role, role_group_name).build())
+        .metadata(
+            object_meta(
+                cluster,
+                &catalog_config_map_name,
+                recommended_labels_for_role_group_resources(cluster, role, role_group_name),
+            )
+            .build(),
+        )
         .data(
             cluster
                 .cluster_config

--- a/rust/operator-binary/src/controller/build/resource/listener.rs
+++ b/rust/operator-binary/src/controller/build/resource/listener.rs
@@ -105,6 +105,12 @@ mod tests {
     use super::*;
     use crate::controller::{app_version_label, validated_cluster};
 
+    #[test]
+    fn test_constants() {
+        // Test that dereferencing the constant does not panic.
+        let _ = *LISTENER_VOLUME_NAME;
+    }
+
     /// The group listener is a role-level (not role-group-level) resource, so it carries the
     /// role-resource recommended labels: a `component` label for the role and no `role-group`
     /// label.

--- a/rust/operator-binary/src/controller/build/resource/listener.rs
+++ b/rust/operator-binary/src/controller/build/resource/listener.rs
@@ -6,16 +6,13 @@ use stackable_operator::{
     crd::listener::v1alpha1::{Listener, ListenerPort, ListenerSpec},
     k8s_openapi::api::core::v1::PersistentVolumeClaim,
     kvp::Labels,
-    v2::types::{
-        kubernetes::{ListenerClassName, VolumeName},
-        operator::RoleGroupName,
-    },
+    v2::types::kubernetes::{ListenerClassName, VolumeName},
 };
 
 use crate::{
     controller::{
         ValidatedCluster,
-        build::{object_meta, ports, recommended_labels_for_role_group_resources},
+        build::{object_meta, ports, recommended_labels_for_role_resources},
     },
     crd::TrinoRole,
 };
@@ -34,15 +31,16 @@ pub enum Error {
 pub fn build_group_listener(
     cluster: &ValidatedCluster,
     role: &TrinoRole,
-    role_group_name: &RoleGroupName,
     listener_class: &ListenerClassName,
     listener_group_name: String,
 ) -> Listener {
+    // The group listener is owned by the role (not a single role-group), so it carries the
+    // role-level recommended labels.
     Listener {
         metadata: object_meta(
             cluster,
             listener_group_name,
-            recommended_labels_for_role_group_resources(cluster, role, role_group_name),
+            recommended_labels_for_role_resources(cluster, role),
         )
         .build(),
         spec: ListenerSpec {
@@ -98,4 +96,44 @@ fn listener_ports(cluster: &ValidatedCluster) -> Vec<ListenerPort> {
         port,
         protocol: Some("TCP".to_string()),
     }]
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+    use crate::controller::{app_version_label, validated_cluster};
+
+    /// The group listener is a role-level (not role-group-level) resource, so it carries the
+    /// role-resource recommended labels: a `component` label for the role and no `role-group`
+    /// label.
+    #[test]
+    fn group_listener_carries_role_level_labels() {
+        let cluster = validated_cluster();
+        let role = TrinoRole::Coordinator;
+        let listener_class: ListenerClassName = "cluster-internal"
+            .parse()
+            .expect("valid ListenerClass name");
+        let listener_group_name =
+            group_listener_name(&cluster, &role).expect("the coordinator has a group listener");
+
+        let listener = build_group_listener(&cluster, &role, &listener_class, listener_group_name);
+
+        let expected_labels: BTreeMap<String, String> = [
+            ("app.kubernetes.io/component", "coordinator".to_string()),
+            ("app.kubernetes.io/instance", "simple-trino".to_string()),
+            (
+                "app.kubernetes.io/managed-by",
+                "trino.stackable.tech_trinocluster".to_string(),
+            ),
+            ("app.kubernetes.io/name", "trino".to_string()),
+            ("app.kubernetes.io/version", app_version_label("481")),
+            ("stackable.tech/vendor", "Stackable".to_string()),
+        ]
+        .into_iter()
+        .map(|(key, value)| (key.to_string(), value))
+        .collect();
+        assert_eq!(listener.metadata.labels, Some(expected_labels));
+    }
 }

--- a/rust/operator-binary/src/controller/build/resource/listener.rs
+++ b/rust/operator-binary/src/controller/build/resource/listener.rs
@@ -6,7 +6,10 @@ use stackable_operator::{
     crd::listener::v1alpha1::{Listener, ListenerPort, ListenerSpec},
     k8s_openapi::api::core::v1::PersistentVolumeClaim,
     kvp::Labels,
-    v2::types::kubernetes::{ListenerClassName, VolumeName},
+    v2::types::{
+        kubernetes::{ListenerClassName, VolumeName},
+        operator::RoleGroupName,
+    },
 };
 
 use crate::{
@@ -30,12 +33,13 @@ pub enum Error {
 
 pub fn build_group_listener(
     cluster: &ValidatedCluster,
-    recommended_labels: Labels,
+    role: &TrinoRole,
+    role_group_name: &RoleGroupName,
     listener_class: &ListenerClassName,
     listener_group_name: String,
 ) -> Listener {
     Listener {
-        metadata: object_meta(cluster, listener_group_name, recommended_labels).build(),
+        metadata: object_meta(cluster, listener_group_name, role, role_group_name).build(),
         spec: ListenerSpec {
             class_name: Some(listener_class.to_string()),
             ports: Some(listener_ports(cluster)),
@@ -64,7 +68,8 @@ pub fn group_listener_name(cluster: &ValidatedCluster, role: &TrinoRole) -> Opti
     match role {
         TrinoRole::Coordinator => Some(format!(
             "{cluster_name}-{role}",
-            cluster_name = cluster.name
+            cluster_name = cluster.name,
+            role = role.as_ref(),
         )),
         TrinoRole::Worker => None,
     }

--- a/rust/operator-binary/src/controller/build/resource/listener.rs
+++ b/rust/operator-binary/src/controller/build/resource/listener.rs
@@ -15,7 +15,7 @@ use stackable_operator::{
 use crate::{
     controller::{
         ValidatedCluster,
-        build::{object_meta, ports},
+        build::{object_meta, ports, recommended_labels_for_role_group_resources},
     },
     crd::TrinoRole,
 };
@@ -39,7 +39,12 @@ pub fn build_group_listener(
     listener_group_name: String,
 ) -> Listener {
     Listener {
-        metadata: object_meta(cluster, listener_group_name, role, role_group_name).build(),
+        metadata: object_meta(
+            cluster,
+            listener_group_name,
+            recommended_labels_for_role_group_resources(cluster, role, role_group_name),
+        )
+        .build(),
         spec: ListenerSpec {
             class_name: Some(listener_class.to_string()),
             ports: Some(listener_ports(cluster)),

--- a/rust/operator-binary/src/controller/build/resource/pdb.rs
+++ b/rust/operator-binary/src/controller/build/resource/pdb.rs
@@ -7,8 +7,9 @@ use stackable_operator::{
 };
 
 use crate::{
-    controller::{ValidatedCluster, controller_name, operator_name, product_name},
+    controller::ValidatedCluster,
     crd::TrinoRole,
+    trino_controller::{CONTROLLER_NAME, OPERATOR_NAME, PRODUCT_NAME},
 };
 
 /// Builds the [`PodDisruptionBudget`] for the given `role`, or `None` if PDBs are disabled.
@@ -29,10 +30,10 @@ pub fn build_pdb(
     let role_name: RoleName = role.into();
     let pdb = pod_disruption_budget_builder_with_role(
         cluster,
-        &product_name(),
+        &PRODUCT_NAME,
         &role_name,
-        &operator_name(),
-        &controller_name(),
+        &OPERATOR_NAME,
+        &CONTROLLER_NAME,
     )
     .with_max_unavailable(max_unavailable)
     .build();

--- a/rust/operator-binary/src/controller/build/resource/rbac.rs
+++ b/rust/operator-binary/src/controller/build/resource/rbac.rs
@@ -1,27 +1,18 @@
 //! Builds the RBAC resources (ServiceAccount + RoleBinding) shared by all role groups.
 
-use std::str::FromStr;
-
 use stackable_operator::{
     k8s_openapi::api::{core::v1::ServiceAccount, rbac::v1::RoleBinding},
-    kvp::Labels,
-    v2::{
-        rbac,
-        types::operator::{RoleGroupName, RoleName},
-    },
+    v2::rbac,
 };
 
-use crate::controller::ValidatedCluster;
-
-stackable_operator::constant!(NONE_ROLE_NAME: RoleName = "none");
-stackable_operator::constant!(NONE_ROLE_GROUP_NAME: RoleGroupName = "none");
+use crate::controller::{ValidatedCluster, build::recommended_labels_for_cluster_resources};
 
 /// Builds the [`ServiceAccount`] that the coordinator and worker Pods run under.
 pub fn build_service_account(cluster: &ValidatedCluster) -> ServiceAccount {
     rbac::build_service_account(
         cluster,
         &cluster.cluster_resource_names(),
-        rbac_labels(cluster),
+        recommended_labels_for_cluster_resources(cluster),
     )
 }
 
@@ -31,14 +22,8 @@ pub fn build_role_binding(cluster: &ValidatedCluster) -> RoleBinding {
     rbac::build_role_binding(
         cluster,
         &cluster.cluster_resource_names(),
-        rbac_labels(cluster),
+        recommended_labels_for_cluster_resources(cluster),
     )
-}
-
-/// Both resources are shared by the whole cluster rather than tied to a role or role group, so
-/// the recommended labels carry `none` for both values.
-fn rbac_labels(cluster: &ValidatedCluster) -> Labels {
-    cluster.recommended_labels_for(&NONE_ROLE_NAME, &NONE_ROLE_GROUP_NAME)
 }
 
 #[cfg(test)]
@@ -61,11 +46,9 @@ mod tests {
                 "metadata": {
                     // The RBAC resources are cluster-shared, so role and role group are `none`.
                     "labels": {
-                        "app.kubernetes.io/component": "none",
                         "app.kubernetes.io/instance": "simple-trino",
                         "app.kubernetes.io/managed-by": "trino.stackable.tech_trinocluster",
                         "app.kubernetes.io/name": "trino",
-                        "app.kubernetes.io/role-group": "none",
                         "app.kubernetes.io/version": app_version_label("481"),
                         "stackable.tech/vendor": "Stackable"
                     },
@@ -96,11 +79,9 @@ mod tests {
                 "kind": "RoleBinding",
                 "metadata": {
                     "labels": {
-                        "app.kubernetes.io/component": "none",
                         "app.kubernetes.io/instance": "simple-trino",
                         "app.kubernetes.io/managed-by": "trino.stackable.tech_trinocluster",
                         "app.kubernetes.io/name": "trino",
-                        "app.kubernetes.io/role-group": "none",
                         "app.kubernetes.io/version": app_version_label("481"),
                         "stackable.tech/vendor": "Stackable"
                     },

--- a/rust/operator-binary/src/controller/build/resource/rbac.rs
+++ b/rust/operator-binary/src/controller/build/resource/rbac.rs
@@ -44,7 +44,6 @@ mod tests {
                 "apiVersion": "v1",
                 "kind": "ServiceAccount",
                 "metadata": {
-                    // The RBAC resources are cluster-shared, so role and role group are `none`.
                     "labels": {
                         "app.kubernetes.io/instance": "simple-trino",
                         "app.kubernetes.io/managed-by": "trino.stackable.tech_trinocluster",

--- a/rust/operator-binary/src/controller/build/resource/service.rs
+++ b/rust/operator-binary/src/controller/build/resource/service.rs
@@ -8,7 +8,7 @@ use stackable_operator::{
 use crate::{
     controller::{
         RoleGroupName, ValidatedCluster,
-        build::{object_meta, ports},
+        build::{object_meta, ports, recommended_labels_for_role_group_resources},
     },
     crd::{METRICS_PORT, METRICS_PORT_NAME, TrinoRole},
 };
@@ -29,8 +29,7 @@ pub fn build_rolegroup_headless_service(
                 .role_group_resource_names(role, role_group_name)
                 .headless_service_name()
                 .to_string(),
-            role,
-            role_group_name,
+            recommended_labels_for_role_group_resources(cluster, role, role_group_name),
         )
         .build(),
         spec: Some(ServiceSpec {
@@ -60,8 +59,7 @@ pub fn build_rolegroup_metrics_service(
                 .role_group_resource_names(role, role_group_name)
                 .metrics_service_name()
                 .to_string(),
-            role,
-            role_group_name,
+            recommended_labels_for_role_group_resources(cluster, role, role_group_name),
         )
         .with_labels(prometheus_labels(&Scraping::Enabled))
         .with_annotations(prometheus_annotations(

--- a/rust/operator-binary/src/controller/build/resource/service.rs
+++ b/rust/operator-binary/src/controller/build/resource/service.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeMap;
 
 use stackable_operator::{
     k8s_openapi::api::core::v1::{Service, ServicePort, ServiceSpec},
-    kvp::Labels,
     v2::builder::service::{Scheme, Scraping, prometheus_annotations, prometheus_labels},
 };
 
@@ -20,7 +19,6 @@ pub fn build_rolegroup_headless_service(
     cluster: &ValidatedCluster,
     role: &TrinoRole,
     role_group_name: &RoleGroupName,
-    recommended_labels: &Labels,
     selector: BTreeMap<String, String>,
     ports: Vec<ServicePort>,
 ) -> Service {
@@ -31,7 +29,8 @@ pub fn build_rolegroup_headless_service(
                 .role_group_resource_names(role, role_group_name)
                 .headless_service_name()
                 .to_string(),
-            recommended_labels.clone(),
+            role,
+            role_group_name,
         )
         .build(),
         spec: Some(ServiceSpec {
@@ -52,7 +51,6 @@ pub fn build_rolegroup_metrics_service(
     cluster: &ValidatedCluster,
     role: &TrinoRole,
     role_group_name: &RoleGroupName,
-    recommended_labels: &Labels,
     selector: BTreeMap<String, String>,
 ) -> Service {
     Service {
@@ -62,7 +60,8 @@ pub fn build_rolegroup_metrics_service(
                 .role_group_resource_names(role, role_group_name)
                 .metrics_service_name()
                 .to_string(),
-            recommended_labels.clone(),
+            role,
+            role_group_name,
         )
         .with_labels(prometheus_labels(&Scraping::Enabled))
         .with_annotations(prometheus_annotations(
@@ -112,7 +111,7 @@ mod tests {
     use stackable_operator::v2::types::operator::RoleGroupName;
 
     use super::*;
-    use crate::controller::{app_version_label, validated_cluster};
+    use crate::controller::{app_version_label, build::role_group_selector, validated_cluster};
 
     /// Every metrics Service must carry the Prometheus scrape label and the
     /// `prometheus.io/path|port|scheme|scrape` annotations, or Prometheus stops discovering the
@@ -122,17 +121,11 @@ mod tests {
         let cluster = validated_cluster();
         let role = TrinoRole::Coordinator;
         let role_group_name: RoleGroupName = "default".parse().expect("valid role group name");
-        // Mirrors how `build()` derives the label arguments.
-        let recommended_labels = cluster.recommended_labels(&role, &role_group_name);
-        let selector = cluster.role_group_selector(&role, &role_group_name);
 
-        let service = build_rolegroup_metrics_service(
-            &cluster,
-            &role,
-            &role_group_name,
-            &recommended_labels,
-            selector.into(),
-        );
+        let selector = role_group_selector(&cluster, &role, &role_group_name);
+
+        let service =
+            build_rolegroup_metrics_service(&cluster, &role, &role_group_name, selector.into());
 
         assert_eq!(
             json!({

--- a/rust/operator-binary/src/controller/build/resource/statefulset.rs
+++ b/rust/operator-binary/src/controller/build/resource/statefulset.rs
@@ -386,12 +386,11 @@ pub fn build_rolegroup_statefulset(
         ));
     }
 
+    let recommended_object_labels =
+        recommended_labels_for_role_group_resources(cluster, trino_role, role_group_name);
+
     let metadata = ObjectMetaBuilder::new()
-        .with_labels(recommended_labels_for_role_group_resources(
-            cluster,
-            trino_role,
-            role_group_name,
-        ))
+        .with_labels(recommended_object_labels.clone())
         .with_annotation(
             // This is actually used by some kuttl tests (as they don't specify the container explicitly)
             Annotation::try_from(("kubectl.kubernetes.io/default-container", "trino"))
@@ -459,8 +458,7 @@ pub fn build_rolegroup_statefulset(
         metadata: object_meta(
             cluster,
             resource_names.stateful_set_name().to_string(),
-            trino_role,
-            role_group_name,
+            recommended_object_labels,
         )
         .with_label(RESTART_CONTROLLER_ENABLED_LABEL.to_owned())
         .with_annotations(annotations)

--- a/rust/operator-binary/src/controller/build/resource/statefulset.rs
+++ b/rust/operator-binary/src/controller/build/resource/statefulset.rs
@@ -21,8 +21,7 @@ use stackable_operator::{
         api::{
             apps::v1::{StatefulSet, StatefulSetSpec},
             core::v1::{
-                ConfigMapVolumeSource, ContainerPort, EnvVar, EnvVarSource, ExecAction,
-                HTTPGetAction, Probe, SecretKeySelector, Volume,
+                ConfigMapVolumeSource, ContainerPort, ExecAction, HTTPGetAction, Probe, Volume,
             },
         },
         apimachinery::pkg::{apis::meta::v1::LabelSelector, util::intstr::IntOrString},
@@ -31,7 +30,10 @@ use stackable_operator::{
     product_logging,
     shared::time::Duration,
     v2::{
-        builder::{pod::container::EnvVarSet, statefulset::restarter_ignore_secret_annotations},
+        builder::{
+            pod::container::{EnvVarName, EnvVarSet},
+            statefulset::restarter_ignore_secret_annotations,
+        },
         product_logging::framework::{ValidatedContainerLogConfigChoice, vector_container},
         types::kubernetes::{ContainerName, SecretClassName, VolumeName},
     },
@@ -55,15 +57,22 @@ use crate::{
     },
     crd::{
         CONFIG_DIR_NAME, Container, ENV_INTERNAL_SECRET, ENV_SPOOLING_SECRET, HTTP_PORT,
-        HTTP_PORT_NAME, HTTPS_PORT, HTTPS_PORT_NAME, MAX_TRINO_LOG_FILES_SIZE, METRICS_PORT,
-        METRICS_PORT_NAME, RW_CONFIG_DIR_NAME, STACKABLE_CLIENT_TLS_DIR,
-        STACKABLE_INTERNAL_TLS_DIR, STACKABLE_MOUNT_INTERNAL_TLS_DIR,
-        STACKABLE_MOUNT_SERVER_TLS_DIR, STACKABLE_SERVER_TLS_DIR, STACKABLE_TLS_STORE_PASSWORD,
-        TrinoRole,
+        HTTP_PORT_NAME, HTTPS_PORT, HTTPS_PORT_NAME, INTERNAL_SECRET_SECRET_KEY,
+        MAX_TRINO_LOG_FILES_SIZE, METRICS_PORT, METRICS_PORT_NAME, RW_CONFIG_DIR_NAME,
+        SPOOLING_SECRET_SECRET_KEY, STACKABLE_CLIENT_TLS_DIR, STACKABLE_INTERNAL_TLS_DIR,
+        STACKABLE_MOUNT_INTERNAL_TLS_DIR, STACKABLE_MOUNT_SERVER_TLS_DIR, STACKABLE_SERVER_TLS_DIR,
+        STACKABLE_TLS_STORE_PASSWORD, TrinoRole,
     },
 };
 
 stackable_operator::constant!(VECTOR_CONTAINER_NAME: ContainerName = "vector");
+
+// The env var the `containerdebug` process (running in the background of the `trino`
+// container) logs its tracing information to. See `command::container_trino_args()` for how
+// the process is called.
+stackable_operator::constant!(
+    CONTAINERDEBUG_LOG_DIRECTORY: EnvVarName = "CONTAINERDEBUG_LOG_DIRECTORY"
+);
 
 // Typed names for the Pod's volumes, so each volume definition and its matching volume mounts
 // stay in sync. The Vector agent reads its `vector.yaml` from the rolegroup ConfigMap (mounted as
@@ -84,6 +93,16 @@ stackable_operator::constant!(INTERNAL_TLS_VOLUME_NAME: VolumeName = "internal-t
 pub enum Error {
     #[snafu(display("missing secret lifetime"))]
     MissingSecretLifetime,
+
+    #[snafu(display("failed to add an authentication environment variable"))]
+    AddAuthenticationEnvVar {
+        source: stackable_operator::v2::builder::pod::container::Error,
+    },
+
+    #[snafu(display("failed to add a catalog environment variable"))]
+    AddCatalogEnvVar {
+        source: stackable_operator::v2::builder::pod::container::Error,
+    },
 
     #[snafu(display("illegal container name: [{container_name}]"))]
     IllegalContainerName {
@@ -170,22 +189,27 @@ pub fn build_rolegroup_statefulset(
         }
     })?;
 
-    // additional authentication env vars
-    let mut env = trino_authentication_config.env_vars(trino_role, &Container::Trino);
+    // Operator-set env vars first; the user's `envOverrides` are merged on top last and win.
+    let mut env = EnvVarSet::new();
 
-    let internal_secret_name = shared_internal_secret_name(&cluster.name);
-    env.push(env_var_from_secret(
-        &internal_secret_name,
-        None,
-        ENV_INTERNAL_SECRET,
-    ));
+    // Additional authentication env vars.
+    for env_var in trino_authentication_config.env_vars(trino_role, &Container::Trino) {
+        env = env
+            .with_env_var(env_var)
+            .context(AddAuthenticationEnvVarSnafu)?;
+    }
 
-    let spooling_secret_name = shared_spooling_secret_name(&cluster.name);
-    env.push(env_var_from_secret(
-        &spooling_secret_name,
-        None,
-        ENV_SPOOLING_SECRET,
-    ));
+    env = env
+        .with_secret_key_ref(
+            &ENV_INTERNAL_SECRET,
+            &shared_internal_secret_name(&cluster.name),
+            &INTERNAL_SECRET_SECRET_KEY,
+        )
+        .with_secret_key_ref(
+            &ENV_SPOOLING_SECRET,
+            &shared_spooling_secret_name(&cluster.name),
+            &SPOOLING_SECRET_SECRET_KEY,
+        );
 
     trino_authentication_config
         .add_authentication_pod_and_volume_config(
@@ -204,25 +228,17 @@ pub fn build_rolegroup_statefulset(
     )
     .context(GracefulShutdownSnafu)?;
 
-    // Add the needed stuff for catalogs
-    env.extend(
-        catalogs
-            .values()
-            .flat_map(|catalog| &catalog.env_bindings)
-            .cloned(),
+    // Add the env vars needed by the catalogs.
+    for env_var in catalogs.values().flat_map(|catalog| &catalog.env_bindings) {
+        env = env
+            .with_env_var(env_var.clone())
+            .context(AddCatalogEnvVarSnafu)?;
+    }
+
+    env = env.with_value(
+        &CONTAINERDEBUG_LOG_DIRECTORY,
+        format!("{STACKABLE_LOG_DIR}/containerdebug"),
     );
-
-    // Needed by the `containerdebug` process to log it's tracing information to.
-    // This process runs in the background of the `trino` container.
-    // See command::container_trino_args() for how it's called.
-    env.push(EnvVar {
-        name: "CONTAINERDEBUG_LOG_DIRECTORY".into(),
-        value: Some(format!("{STACKABLE_LOG_DIR}/containerdebug")),
-        ..EnvVar::default()
-    });
-
-    // Finally add the user defined envOverrides properties.
-    env.extend(env_overrides.clone());
 
     let requested_secret_lifetime = merged_config
         .requested_secret_lifetime
@@ -331,7 +347,7 @@ pub fn build_rolegroup_statefulset(
         .args(vec![
             command::container_trino_args(trino_authentication_config, catalogs).join("\n"),
         ])
-        .add_env_vars(env)
+        .add_env_vars(env.merge(env_overrides.clone()))
         .add_volume_mount(&*CONFIG_VOLUME_NAME, CONFIG_DIR_NAME)
         .context(AddVolumeMountSnafu)?
         .add_volume_mount(&*RW_CONFIG_VOLUME_NAME, RW_CONFIG_DIR_NAME)
@@ -481,24 +497,6 @@ pub fn build_rolegroup_statefulset(
         }),
         status: None,
     })
-}
-
-/// Give a secret name and an optional key in the secret to use.
-/// The value from the key will be set into the given env var name.
-/// If not secret key is given, the env var name will be used as the secret key.
-fn env_var_from_secret(secret_name: &str, secret_key: Option<&str>, env_var: &str) -> EnvVar {
-    EnvVar {
-        name: env_var.to_string(),
-        value_from: Some(EnvVarSource {
-            secret_key_ref: Some(SecretKeySelector {
-                optional: Some(false),
-                name: secret_name.to_string(),
-                key: secret_key.unwrap_or(env_var).to_string(),
-            }),
-            ..EnvVarSource::default()
-        }),
-        ..EnvVar::default()
-    }
 }
 
 fn container_ports(cluster: &ValidatedCluster) -> Vec<ContainerPort> {
@@ -796,4 +794,65 @@ fn tls_volume_mounts(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use stackable_operator::v2::builder::pod::container::EnvVarName;
+
+    use super::*;
+    use crate::controller::validated_cluster;
+
+    #[test]
+    fn test_constants() {
+        // Test that dereferencing the constant does not panic.
+        let _ = *CONTAINERDEBUG_LOG_DIRECTORY;
+    }
+
+    /// The user-supplied `envOverrides` must be merged in after all operator-set environment
+    /// variables, so that they can override any of them. `CONTAINERDEBUG_LOG_DIRECTORY` is used
+    /// as the example here because it is set unconditionally by the operator.
+    #[test]
+    fn env_overrides_take_precedence_over_operator_set_env_vars() {
+        let cluster = validated_cluster();
+        let role_group_name = RoleGroupName::from_str("default").expect("valid role group name");
+        let mut role_group_config =
+            cluster.role_group_configs[&TrinoRole::Coordinator][&role_group_name].clone();
+        role_group_config.env_overrides = EnvVarSet::new().with_value(
+            &EnvVarName::from_str("CONTAINERDEBUG_LOG_DIRECTORY").expect("valid env var name"),
+            "/custom/log/dir",
+        );
+
+        let stateful_set = build_rolegroup_statefulset(
+            &cluster,
+            &TrinoRole::Coordinator,
+            &role_group_name,
+            &role_group_config,
+        )
+        .expect("the StatefulSet builds");
+
+        let env = stateful_set
+            .spec
+            .expect("the StatefulSet has a spec")
+            .template
+            .spec
+            .expect("the pod template has a spec")
+            .containers
+            .into_iter()
+            .find(|container| container.name == "trino")
+            .expect("the trino container exists")
+            .env
+            .expect("the trino container has env vars");
+
+        let containerdebug: Vec<_> = env
+            .iter()
+            .filter(|env_var| env_var.name == "CONTAINERDEBUG_LOG_DIRECTORY")
+            .collect();
+        assert_eq!(
+            containerdebug.len(),
+            1,
+            "exactly one CONTAINERDEBUG_LOG_DIRECTORY entry must survive, got: {containerdebug:?}"
+        );
+        assert_eq!(containerdebug[0].value.as_deref(), Some("/custom/log/dir"));
+    }
 }

--- a/rust/operator-binary/src/controller/build/resource/statefulset.rs
+++ b/rust/operator-binary/src/controller/build/resource/statefulset.rs
@@ -805,8 +805,19 @@ mod tests {
 
     #[test]
     fn test_constants() {
-        // Test that dereferencing the constant does not panic.
+        // Test that dereferencing the constants does not panic.
+        let _ = *VECTOR_CONTAINER_NAME;
         let _ = *CONTAINERDEBUG_LOG_DIRECTORY;
+        let _ = *CONFIG_VOLUME_NAME;
+        let _ = *RW_CONFIG_VOLUME_NAME;
+        let _ = *CATALOG_VOLUME_NAME;
+        let _ = *LOG_CONFIG_VOLUME_NAME;
+        let _ = *LOG_VOLUME_NAME;
+        let _ = *SERVER_TLS_MOUNT_VOLUME_NAME;
+        let _ = *SERVER_TLS_VOLUME_NAME;
+        let _ = *CLIENT_TLS_VOLUME_NAME;
+        let _ = *INTERNAL_TLS_MOUNT_VOLUME_NAME;
+        let _ = *INTERNAL_TLS_VOLUME_NAME;
     }
 
     /// The user-supplied `envOverrides` must be merged in after all operator-set environment

--- a/rust/operator-binary/src/controller/build/resource/statefulset.rs
+++ b/rust/operator-binary/src/controller/build/resource/statefulset.rs
@@ -43,11 +43,13 @@ use crate::{
         MAX_PREPARE_LOG_FILE_SIZE, RoleGroupName, STACKABLE_LOG_CONFIG_DIR, STACKABLE_LOG_DIR,
         TrinoRoleGroupConfig, ValidatedCluster,
         build::{
-            self, command, object_meta,
+            self, command, object_meta, recommended_labels_for_role_group_resources,
+            recommended_labels_for_unversioned_role_group_resources,
             resource::listener::{
                 LISTENER_VOLUME_DIR, LISTENER_VOLUME_NAME, build_group_listener_pvc,
                 group_listener_name, secret_volume_listener_scope,
             },
+            role_group_selector,
         },
         shared_internal_secret_name, shared_spooling_secret_name,
     },
@@ -305,7 +307,11 @@ pub fn build_rolegroup_statefulset(
         // Used for PVC templates that cannot be modified once they are deployed, so a fixed
         // "none" version is used while keeping the other recommended labels.
         let unversioned_recommended_labels =
-            cluster.unversioned_recommended_labels(trino_role, role_group_name);
+            recommended_labels_for_unversioned_role_group_resources(
+                cluster,
+                trino_role,
+                role_group_name,
+            );
 
         persistent_volume_claims.push(
             build_group_listener_pvc(&group_listener_name, &unversioned_recommended_labels)
@@ -381,7 +387,11 @@ pub fn build_rolegroup_statefulset(
     }
 
     let metadata = ObjectMetaBuilder::new()
-        .with_labels(cluster.recommended_labels(trino_role, role_group_name))
+        .with_labels(recommended_labels_for_role_group_resources(
+            cluster,
+            trino_role,
+            role_group_name,
+        ))
         .with_annotation(
             // This is actually used by some kuttl tests (as they don't specify the container explicitly)
             Annotation::try_from(("kubectl.kubernetes.io/default-container", "trino"))
@@ -449,7 +459,8 @@ pub fn build_rolegroup_statefulset(
         metadata: object_meta(
             cluster,
             resource_names.stateful_set_name().to_string(),
-            cluster.recommended_labels(trino_role, role_group_name),
+            trino_role,
+            role_group_name,
         )
         .with_label(RESTART_CONTROLLER_ENABLED_LABEL.to_owned())
         .with_annotations(annotations)
@@ -461,9 +472,7 @@ pub fn build_rolegroup_statefulset(
             replicas: role_group_config.replicas.map(i32::from),
             selector: LabelSelector {
                 match_labels: Some(
-                    cluster
-                        .role_group_selector(trino_role, role_group_name)
-                        .into(),
+                    role_group_selector(cluster, trino_role, role_group_name).into(),
                 ),
                 ..LabelSelector::default()
             },

--- a/rust/operator-binary/src/controller/mod.rs
+++ b/rust/operator-binary/src/controller/mod.rs
@@ -21,7 +21,7 @@ use stackable_operator::{
         role_group_utils::ResourceNames,
         role_utils,
         types::{
-            kubernetes::{ListenerClassName, NamespaceName, SecretClassName, Uid},
+            kubernetes::{ListenerClassName, NamespaceName, SecretClassName, SecretName, Uid},
             operator::{ClusterName, ProductVersion},
         },
     },
@@ -54,12 +54,16 @@ pub const MAX_PREPARE_LOG_FILE_SIZE: MemoryQuantity = MemoryQuantity {
     unit: BinaryMultiple::Mebi,
 };
 
-pub(crate) fn shared_internal_secret_name(cluster_name: &ClusterName) -> String {
+pub(crate) fn shared_internal_secret_name(cluster_name: &ClusterName) -> SecretName {
     format!("{cluster_name}-internal-secret")
+        .parse()
+        .expect("a ClusterName (at most 40 characters) plus '-internal-secret' fits the SecretName limit of 253 characters")
 }
 
-pub(crate) fn shared_spooling_secret_name(cluster_name: &ClusterName) -> String {
+pub(crate) fn shared_spooling_secret_name(cluster_name: &ClusterName) -> SecretName {
     format!("{cluster_name}-spooling-secret")
+        .parse()
+        .expect("a ClusterName (at most 40 characters) plus '-spooling-secret' fits the SecretName limit of 253 characters")
 }
 
 /// Marker for prepared Kubernetes resources which are not applied yet.

--- a/rust/operator-binary/src/controller/mod.rs
+++ b/rust/operator-binary/src/controller/mod.rs
@@ -62,9 +62,6 @@ pub(crate) fn shared_spooling_secret_name(cluster_name: &ClusterName) -> String 
     format!("{cluster_name}-spooling-secret")
 }
 
-// Placeholder version label value for resources whose labels must not change after deployment.
-stackable_operator::constant!(UNVERSIONED_PRODUCT_VERSION: ProductVersion = "none");
-
 /// Marker for prepared Kubernetes resources which are not applied yet.
 pub struct Prepared;
 

--- a/rust/operator-binary/src/controller/mod.rs
+++ b/rust/operator-binary/src/controller/mod.rs
@@ -14,19 +14,15 @@ use stackable_operator::{
         rbac::v1::RoleBinding,
     },
     kube::{Resource, api::ObjectMeta},
-    kvp::Labels,
     memory::{BinaryMultiple, MemoryQuantity},
     shared::time::Duration,
     v2::{
         HasName, HasUid, NameIsValidLabelValue,
-        kvp::label::{recommended_labels, role_group_selector},
         role_group_utils::ResourceNames,
         role_utils,
         types::{
             kubernetes::{ListenerClassName, NamespaceName, SecretClassName, Uid},
-            operator::{
-                ClusterName, ControllerName, OperatorName, ProductName, ProductVersion, RoleName,
-            },
+            operator::{ClusterName, ProductVersion},
         },
     },
 };
@@ -39,8 +35,8 @@ use crate::{
         client_protocol::ResolvedClientProtocolConfig,
         fault_tolerant_execution::ResolvedFaultTolerantExecutionConfig,
     },
-    crd::{APP_NAME, TrinoRole, catalog::TrinoCatalogName, discovery::TrinoPodRef, v1alpha1},
-    trino_controller::{CONTROLLER_NAME, OPERATOR_NAME},
+    crd::{TrinoRole, catalog::TrinoCatalogName, discovery::TrinoPodRef, v1alpha1},
+    trino_controller::PRODUCT_NAME,
 };
 
 pub(crate) mod apply;
@@ -248,7 +244,7 @@ impl ValidatedCluster {
     pub fn cluster_resource_names(&self) -> role_utils::ResourceNames {
         role_utils::ResourceNames {
             cluster_name: self.name.clone(),
-            product_name: product_name(),
+            product_name: PRODUCT_NAME.clone(),
         }
     }
 
@@ -277,54 +273,6 @@ impl ValidatedCluster {
             self.role_group_resource_names(role, role_group_name)
                 .role_group_config_map()
         )
-    }
-
-    /// A [`TrinoRole`] as a type-safe [`RoleName`].
-    fn recommended_labels_with(
-        &self,
-        version: &ProductVersion,
-        role_name: &RoleName,
-        role_group_name: &RoleGroupName,
-    ) -> Labels {
-        recommended_labels(
-            self,
-            &product_name(),
-            version,
-            &operator_name(),
-            &controller_name(),
-            role_name,
-            role_group_name,
-        )
-    }
-
-    /// Recommended labels for a role-group resource (using the resolved product version).
-    pub fn recommended_labels(&self, role: &TrinoRole, role_group_name: &RoleGroupName) -> Labels {
-        self.recommended_labels_for(&role.into(), role_group_name)
-    }
-
-    /// Recommended labels for a resource that is not tied to a concrete [`TrinoRole`] (e.g. the
-    /// cluster-shared RBAC resources), using a free-form role/role-group label value.
-    pub fn recommended_labels_for(
-        &self,
-        role_name: &RoleName,
-        role_group_name: &RoleGroupName,
-    ) -> Labels {
-        self.recommended_labels_with(&self.product_version, role_name, role_group_name)
-    }
-
-    /// Recommended labels with the constant [`UNVERSIONED_PRODUCT_VERSION`], for resources whose
-    /// labels must not change after creation (e.g. listener PVC templates).
-    pub fn unversioned_recommended_labels(
-        &self,
-        role: &TrinoRole,
-        role_group_name: &RoleGroupName,
-    ) -> Labels {
-        self.recommended_labels_with(&UNVERSIONED_PRODUCT_VERSION, &role.into(), role_group_name)
-    }
-
-    /// Selector labels matching the pods of a role group.
-    pub fn role_group_selector(&self, role: &TrinoRole, role_group_name: &RoleGroupName) -> Labels {
-        role_group_selector(self, &product_name(), &role.into(), role_group_name)
     }
 }
 
@@ -373,21 +321,6 @@ impl NameIsValidLabelValue for ValidatedCluster {
     fn to_label_value(&self) -> String {
         self.name.to_label_value()
     }
-}
-
-/// The product name (`trino`) as a type-safe label value.
-pub(crate) fn product_name() -> ProductName {
-    ProductName::from_str(APP_NAME).expect("'trino' is a valid product name")
-}
-
-/// The operator name as a type-safe label value.
-pub(crate) fn operator_name() -> OperatorName {
-    OperatorName::from_str(OPERATOR_NAME).expect("the operator name is a valid label value")
-}
-
-/// The controller name as a type-safe label value.
-pub(crate) fn controller_name() -> ControllerName {
-    ControllerName::from_str(CONTROLLER_NAME).expect("the controller name is a valid label value")
 }
 
 /// The expected `app.kubernetes.io/version` label value for the given product version.

--- a/rust/operator-binary/src/controller/update_status.rs
+++ b/rust/operator-binary/src/controller/update_status.rs
@@ -13,7 +13,7 @@ use strum::{EnumDiscriminants, IntoStaticStr};
 use crate::{
     controller::{Applied, KubernetesResources},
     crd::v1alpha1,
-    trino_controller::OPERATOR_NAME,
+    trino_controller::TRINO_OPERATOR_NAME,
 };
 
 #[derive(Snafu, Debug, EnumDiscriminants)]
@@ -54,7 +54,7 @@ pub async fn update_status(
     };
 
     client
-        .apply_patch_status(OPERATOR_NAME, trino, &status)
+        .apply_patch_status(TRINO_OPERATOR_NAME, trino, &status)
         .await
         .context(ApplyStatusSnafu)?;
 

--- a/rust/operator-binary/src/controller/validate.rs
+++ b/rust/operator-binary/src/controller/validate.rs
@@ -12,15 +12,14 @@ use stackable_operator::{
     config::fragment,
     kube::ResourceExt as _,
     product_logging::spec::Logging,
-    role_utils::{GenericRoleConfig, RoleGroup},
+    role_utils::GenericRoleConfig,
     v2::{
-        builder::pod::container::{EnvVarName, EnvVarSet},
         controller_utils::{get_cluster_name, get_namespace, get_uid},
         product_logging::framework::{
             ValidatedContainerLogConfigChoice, VectorContainerLogConfig,
             validate_logging_configuration_for_container,
         },
-        role_utils::{JavaCommonConfig, RoleGroupConfig, with_validated_config},
+        role_utils::{JavaCommonConfig, RoleGroup, RoleGroupConfig, with_validated_config},
         types::kubernetes::ConfigMapName,
     },
 };
@@ -86,11 +85,6 @@ pub enum Error {
     FailedToResolveConfig {
         source: fragment::ValidationError,
         role_group: RoleGroupName,
-    },
-
-    #[snafu(display("invalid environment variable override name"))]
-    ParseEnvVarName {
-        source: stackable_operator::v2::macros::attributed_string_type::Error,
     },
 
     #[snafu(display("failed to validate logging configuration"))]
@@ -316,21 +310,13 @@ fn into_role_group_config(
     let replicas = merged.replicas;
     let common = merged.config;
 
-    let mut env_overrides = EnvVarSet::new();
-    for (name, value) in common.env_overrides {
-        env_overrides = env_overrides.with_value(
-            &EnvVarName::from_str(&name).context(ParseEnvVarNameSnafu)?,
-            value,
-        );
-    }
-
     let logging = validate_logging(&common.config.logging, vector_aggregator_config_map_name)?;
 
     Ok(RoleGroupConfig {
         replicas,
         config: ValidatedTrinoConfig::from_merged(common.config, logging),
         config_overrides: common.config_overrides,
-        env_overrides,
+        env_overrides: common.env_overrides.into(),
         cli_overrides: common.cli_overrides,
         pod_overrides: common.pod_overrides,
         product_specific_common_config: common.product_specific_common_config,
@@ -618,36 +604,6 @@ mod tests {
         });
 
         assert!(validate_yaml(&minimal_yaml("481"), &derefs).is_ok());
-    }
-
-    #[test]
-    fn rejects_invalid_env_override_name() {
-        let yaml = r#"
-            apiVersion: trino.stackable.tech/v1alpha1
-            kind: TrinoCluster
-            metadata:
-              name: simple-trino
-              namespace: default
-              uid: "e6ac237d-a6d4-43a1-8135-f36506110912"
-            spec:
-              image:
-                productVersion: "481"
-              clusterConfig:
-                catalogLabelSelector: {}
-              coordinators:
-                roleGroups:
-                  default:
-                    replicas: 1
-                    envOverrides:
-                      "BAD=NAME": "value"
-              workers:
-                roleGroups:
-                  default:
-                    replicas: 1
-            "#;
-
-        let err = validate_yaml(yaml, &empty_derefs()).unwrap_err();
-        assert!(matches!(err, Error::ParseEnvVarName { .. }));
     }
 
     #[test]

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -618,6 +618,8 @@ mod tests {
         let _ = *INTERNAL_SECRET_SECRET_KEY;
         let _ = *ENV_SPOOLING_SECRET;
         let _ = *SPOOLING_SECRET_SECRET_KEY;
+        let _ = *COORDINATOR_ROLE_NAME;
+        let _ = *WORKER_ROLE_NAME;
     }
 
     /// The user-provided server TLS SecretClass as `Option<&str>`, used by these CRD-defaulting

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -5,7 +5,7 @@ pub mod client_protocol;
 pub mod discovery;
 pub mod fault_tolerant_execution;
 
-use std::{collections::BTreeMap, str::FromStr};
+use std::{collections::BTreeMap, ops::Deref, str::FromStr};
 
 use affinity::get_affinity;
 use serde::{Deserialize, Serialize};
@@ -21,20 +21,21 @@ use stackable_operator::{
         },
     },
     config::{fragment::Fragment, merge::Merge},
+    constant,
     crd::authentication::core,
     deep_merger::ObjectOverrides,
     k8s_openapi::apimachinery::pkg::{api::resource::Quantity, apis::meta::v1::LabelSelector},
     kube::{CustomResource, ResourceExt},
     memory::{BinaryMultiple, MemoryQuantity},
     product_logging::{self, spec::Logging},
-    role_utils::{GenericRoleConfig, Role},
+    role_utils::GenericRoleConfig,
     schemars::{self, JsonSchema},
     shared::time::Duration,
     status::condition::{ClusterCondition, HasStatusCondition},
     v2::{
         config_overrides::KeyValueConfigOverrides,
         role_group_utils::ResourceNames,
-        role_utils::JavaCommonConfig,
+        role_utils::{JavaCommonConfig, Role},
         types::{
             common::Port,
             kubernetes::{ConfigMapName, ListenerClassName, NamespaceName, SecretClassName},
@@ -389,37 +390,41 @@ fn tls_secret_class_default() -> Option<SecretClassName> {
     )
 }
 
-#[derive(
-    Clone,
-    Debug,
-    Deserialize,
-    Display,
-    EnumIter,
-    Eq,
-    Hash,
-    JsonSchema,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    Serialize,
-    EnumString,
-)]
+constant!(COORDINATOR_ROLE_NAME: RoleName = "coordinator");
+constant!(WORKER_ROLE_NAME: RoleName = "worker");
+
+#[derive(Clone, Debug, EnumIter, EnumString, Eq, Hash, JsonSchema, Ord, PartialEq, PartialOrd)]
 pub enum TrinoRole {
-    #[strum(serialize = "coordinator")]
     Coordinator,
-    #[strum(serialize = "worker")]
     Worker,
+}
+
+impl Deref for TrinoRole {
+    type Target = RoleName;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            TrinoRole::Coordinator => &COORDINATOR_ROLE_NAME,
+            TrinoRole::Worker => &WORKER_ROLE_NAME,
+        }
+    }
 }
 
 impl From<TrinoRole> for RoleName {
     fn from(value: TrinoRole) -> Self {
-        RoleName::from_str(&value.to_string()).expect("a TrinoRole is a valid role name")
+        value
+            .to_string()
+            .parse()
+            .expect("a TrinoRole serialises to a valid RoleName")
     }
 }
 
 impl From<&TrinoRole> for RoleName {
     fn from(value: &TrinoRole) -> Self {
-        RoleName::from_str(&value.to_string()).expect("a TrinoRole is a valid role name")
+        value
+            .to_string()
+            .parse()
+            .expect("a TrinoRole serialises to a valid RoleName")
     }
 }
 

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -44,7 +44,7 @@ use stackable_operator::{
     },
     versioned::versioned,
 };
-use strum::{Display, EnumIter, EnumString};
+use strum::{Display, EnumIter};
 
 use crate::crd::discovery::TrinoPodRef;
 
@@ -393,7 +393,7 @@ fn tls_secret_class_default() -> Option<SecretClassName> {
 constant!(COORDINATOR_ROLE_NAME: RoleName = "coordinator");
 constant!(WORKER_ROLE_NAME: RoleName = "worker");
 
-#[derive(Clone, Debug, EnumIter, EnumString, Eq, Hash, JsonSchema, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, EnumIter, Eq, Hash, JsonSchema, Ord, PartialEq, PartialOrd)]
 pub enum TrinoRole {
     Coordinator,
     Worker,

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -33,12 +33,15 @@ use stackable_operator::{
     shared::time::Duration,
     status::condition::{ClusterCondition, HasStatusCondition},
     v2::{
+        builder::pod::container::EnvVarName,
         config_overrides::KeyValueConfigOverrides,
         role_group_utils::ResourceNames,
         role_utils::{JavaCommonConfig, Role},
         types::{
             common::Port,
-            kubernetes::{ConfigMapName, ListenerClassName, NamespaceName, SecretClassName},
+            kubernetes::{
+                ConfigMapName, ListenerClassName, NamespaceName, SecretClassName, SecretKey,
+            },
             operator::{ClusterName, RoleGroupName, RoleName},
         },
     },
@@ -82,9 +85,13 @@ pub const STACKABLE_MOUNT_SERVER_TLS_DIR: &str = "/stackable/mount_server_tls";
 pub const STACKABLE_MOUNT_INTERNAL_TLS_DIR: &str = "/stackable/mount_internal_tls";
 // store pws
 pub const STACKABLE_TLS_STORE_PASSWORD: &str = "changeit";
-// secret vars
-pub const ENV_INTERNAL_SECRET: &str = "INTERNAL_SECRET";
-pub const ENV_SPOOLING_SECRET: &str = "SPOOLING_SECRET";
+// Env vars mounting the shared random Secrets, and the keys under which the Secrets store
+// their value. Name and key deliberately share the same string, so `${ENV:...}` references in
+// the generated properties match the Secret contents.
+constant!(pub ENV_INTERNAL_SECRET: EnvVarName = "INTERNAL_SECRET");
+constant!(pub INTERNAL_SECRET_SECRET_KEY: SecretKey = "INTERNAL_SECRET");
+constant!(pub ENV_SPOOLING_SECRET: EnvVarName = "SPOOLING_SECRET");
+constant!(pub SPOOLING_SECRET_SECRET_KEY: SecretKey = "SPOOLING_SECRET");
 // TLS
 const TLS_DEFAULT_SECRET_CLASS: &str = "tls";
 // Listener
@@ -603,6 +610,15 @@ mod tests {
     use stackable_operator::versioned::test_utils::RoundtripTestData;
 
     use super::*;
+
+    #[test]
+    fn test_constants() {
+        // Test that dereferencing the constants does not panic.
+        let _ = *ENV_INTERNAL_SECRET;
+        let _ = *INTERNAL_SECRET_SECRET_KEY;
+        let _ = *ENV_SPOOLING_SECRET;
+        let _ = *SPOOLING_SECRET_SECRET_KEY;
+    }
 
     /// The user-provided server TLS SecretClass as `Option<&str>`, used by these CRD-defaulting
     /// assertions.

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -37,7 +37,7 @@ use crate::{
         catalog::{TrinoCatalog, TrinoCatalogVersion},
         v1alpha1,
     },
-    trino_controller::{FULL_CONTROLLER_NAME, OPERATOR_NAME},
+    trino_controller::{FULL_CONTROLLER_NAME, TRINO_OPERATOR_NAME},
     webhooks::conversion::create_webhook_server,
 };
 
@@ -104,7 +104,7 @@ async fn main() -> anyhow::Result<()> {
                     .map(anyhow::Ok);
 
             let client = stackable_operator::client::initialize_operator(
-                Some(OPERATOR_NAME.to_string()),
+                Some(TRINO_OPERATOR_NAME.to_string()),
                 &common.cluster_info,
             )
             .await?;

--- a/rust/operator-binary/src/trino_controller.rs
+++ b/rust/operator-binary/src/trino_controller.rs
@@ -5,19 +5,21 @@
 //! type and the individual steps live under the [`crate::controller`] module tree; this file is
 //! kept next to `main.rs` for consistency with the other Stackable operators.
 
-use std::sync::Arc;
+use std::{str::FromStr, sync::Arc};
 
 use const_format::concatcp;
 use snafu::{ResultExt, Snafu};
 use stackable_operator::{
     cli::OperatorEnvironmentOptions,
     cluster_resources::ClusterResourceApplyStrategy,
+    constant,
     kube::{
         core::{DeserializeGuard, error_boundary},
         runtime::controller::Action,
     },
     logging::controller::ReconcilerError,
     shared::time::Duration,
+    v2::types::operator::{ControllerName, OperatorName, ProductName},
 };
 use strum::{EnumDiscriminants, IntoStaticStr};
 
@@ -28,7 +30,7 @@ use crate::{
         update_status::{self, update_status},
         validate,
     },
-    crd::v1alpha1,
+    crd::{APP_NAME, v1alpha1},
 };
 
 pub struct Ctx {
@@ -36,9 +38,13 @@ pub struct Ctx {
     pub operator_environment: OperatorEnvironmentOptions,
 }
 
-pub const OPERATOR_NAME: &str = "trino.stackable.tech";
-pub const CONTROLLER_NAME: &str = "trinocluster";
-pub const FULL_CONTROLLER_NAME: &str = concatcp!(CONTROLLER_NAME, '.', OPERATOR_NAME);
+pub const TRINO_OPERATOR_NAME: &str = "trino.stackable.tech";
+pub const TRINO_CONTROLLER_NAME: &str = "trinocluster";
+pub const FULL_CONTROLLER_NAME: &str = concatcp!(TRINO_CONTROLLER_NAME, '.', TRINO_OPERATOR_NAME);
+
+constant!(pub(crate) PRODUCT_NAME: ProductName = APP_NAME);
+constant!(pub(crate) OPERATOR_NAME: OperatorName = TRINO_OPERATOR_NAME);
+constant!(pub(crate) CONTROLLER_NAME: ControllerName = TRINO_CONTROLLER_NAME);
 
 pub(crate) const CONTAINER_IMAGE_BASE_NAME: &str = "trino";
 
@@ -237,15 +243,12 @@ mod tests {
 
         let trino_role = TrinoRole::Coordinator;
         let role_group_name = RoleGroupName::from_str("default").expect("valid role group name");
-        let recommended_labels =
-            validated_cluster.recommended_labels(&trino_role, &role_group_name);
 
         build::resource::config_map::build_rolegroup_config_map(
             &validated_cluster,
             &trino_role,
             &role_group_name,
             &cluster_info,
-            &recommended_labels,
         )
         .expect("build_rolegroup_config_map should succeed")
     }

--- a/rust/operator-binary/src/trino_controller.rs
+++ b/rust/operator-binary/src/trino_controller.rs
@@ -362,8 +362,8 @@ mod tests {
         let config = cm.get("config.properties").unwrap();
         assert!(config.contains("protocol.spooling.enabled=true"));
         assert!(config.contains(&format!(
-            "protocol.spooling.shared-secret-key=${{ENV\\:{}}}",
-            ENV_SPOOLING_SECRET.as_ref()
+            "protocol.spooling.shared-secret-key=${{ENV\\:{env_spooling_secret}}}",
+            env_spooling_secret = ENV_SPOOLING_SECRET.as_ref()
         )));
         assert!(config.contains("foo=bar"));
 

--- a/rust/operator-binary/src/trino_controller.rs
+++ b/rust/operator-binary/src/trino_controller.rs
@@ -354,7 +354,8 @@ mod tests {
         let config = cm.get("config.properties").unwrap();
         assert!(config.contains("protocol.spooling.enabled=true"));
         assert!(config.contains(&format!(
-            "protocol.spooling.shared-secret-key=${{ENV\\:{ENV_SPOOLING_SECRET}}}"
+            "protocol.spooling.shared-secret-key=${{ENV\\:{}}}",
+            ENV_SPOOLING_SECRET.as_ref()
         )));
         assert!(config.contains("foo=bar"));
 

--- a/rust/operator-binary/src/trino_controller.rs
+++ b/rust/operator-binary/src/trino_controller.rs
@@ -171,6 +171,14 @@ mod tests {
         crd::{ENV_SPOOLING_SECRET, TrinoRole, v1alpha1},
     };
 
+    #[test]
+    fn test_constants() {
+        // Test that dereferencing the constants does not panic.
+        let _ = *PRODUCT_NAME;
+        let _ = *OPERATOR_NAME;
+        let _ = *CONTROLLER_NAME;
+    }
+
     async fn build_config_map(trino_yaml: &str) -> ConfigMap {
         let deserializer = serde_yaml::Deserializer::from_str(trino_yaml);
         let mut trino: v1alpha1::TrinoCluster =

--- a/tests/templates/kuttl/smoke/13-assert.yaml
+++ b/tests/templates/kuttl/smoke/13-assert.yaml
@@ -416,7 +416,6 @@ metadata:
     app.kubernetes.io/instance: trino
     app.kubernetes.io/managed-by: trino.stackable.tech_trinocluster
     app.kubernetes.io/name: trino
-    app.kubernetes.io/role-group: none
     stackable.tech/vendor: Stackable
   ownerReferences:
     - apiVersion: trino.stackable.tech/v1alpha1


### PR DESCRIPTION
## Description

Upgrade to stackable-operator 0.116.0 and apply the changes described in stackabletech/issues#877.

Part of stackabletech/issues#877

```
--- PASS: kuttl (1055.62s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_trino-481_hive-4.2.0_opa-latest-1.16.2_hdfs-3.5.0_zookeeper-3.9.5_openshift-false (1055.61s)
PASS
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [x] Release note snippet added in parent issue

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
