### PR TITLE
fix: replace deref with accessor function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ All notable changes to this project will be documented in this file.
   templates (all previously set to the placeholder value `none`). After the operator upgrade,
   delete each coordinator StatefulSet so that the operator immediately recreates it with the
   new labels ([#932]).
-- Make operations infallible where dependent on static inputs ([#939]).
+- Make operations infallible where dependent on static inputs ([#939], [#943]).
 
 ### Fixed
 
@@ -48,6 +48,7 @@ All notable changes to this project will be documented in this file.
 [#932]: https://github.com/stackabletech/trino-operator/pull/932
 [#934]: https://github.com/stackabletech/trino-operator/pull/934
 [#939]: https://github.com/stackabletech/trino-operator/pull/939
+[#943]: https://github.com/stackabletech/trino-operator/pull/943
 
 ## [26.7.0] - 2026-07-21
 

--- a/rust/operator-binary/src/authentication/password/file.rs
+++ b/rust/operator-binary/src/authentication/password/file.rs
@@ -133,7 +133,8 @@ pub fn build_password_file_update_container(
     resolved_product_image: &ResolvedProductImage,
     volume_mounts: Vec<VolumeMount>,
 ) -> Result<Container, Error> {
-    let mut cb_pw_file_updater = new_container_builder(&crate::crd::Container::PasswordFileUpdater);
+    let mut cb_pw_file_updater =
+        new_container_builder(crate::crd::Container::PasswordFileUpdater.name());
 
     let mut commands = vec![];
 

--- a/rust/operator-binary/src/authentication/password/file.rs
+++ b/rust/operator-binary/src/authentication/password/file.rs
@@ -140,7 +140,7 @@ pub fn build_password_file_update_container(
 
     commands.push(product_logging::framework::capture_shell_output(
         STACKABLE_LOG_DIR,
-        &crate::crd::Container::PasswordFileUpdater.to_string(),
+        crate::crd::Container::PasswordFileUpdater.name().as_ref(),
         // we do not access any of the crd config options for this and just log it to file
         &AutomaticContainerLogConfig::default(),
     ));

--- a/rust/operator-binary/src/controller/build/graceful_shutdown.rs
+++ b/rust/operator-binary/src/controller/build/graceful_shutdown.rs
@@ -315,7 +315,7 @@ mod tests {
             .expect("the fixture defines a worker role group")
             .config;
         let mut pod_builder = PodBuilder::new();
-        let mut trino_builder = new_container_builder(&Container::Trino);
+        let mut trino_builder = new_container_builder(Container::Trino.name());
         add_graceful_shutdown_config(
             &cluster,
             &TrinoRole::Worker,
@@ -354,7 +354,7 @@ mod tests {
             .expect("the fixture defines a coordinator role group")
             .config;
         let mut pod_builder = PodBuilder::new();
-        let mut trino_builder = new_container_builder(&Container::Trino);
+        let mut trino_builder = new_container_builder(Container::Trino.name());
         add_graceful_shutdown_config(
             &cluster,
             &TrinoRole::Coordinator,

--- a/rust/operator-binary/src/controller/build/properties/config_properties.rs
+++ b/rust/operator-binary/src/controller/build/properties/config_properties.rs
@@ -102,7 +102,7 @@ pub fn build(
         LOG_PATH.to_string(),
         format!(
             "{STACKABLE_LOG_DIR}/{container}/server.airlift.json",
-            container = Container::Trino
+            container = Container::Trino.name()
         ),
     );
     props.insert(LOG_COMPRESSION.to_string(), "none".to_string());

--- a/rust/operator-binary/src/controller/build/resource/statefulset.rs
+++ b/rust/operator-binary/src/controller/build/resource/statefulset.rs
@@ -320,7 +320,7 @@ pub fn build_rolegroup_statefulset(
     {
         prepare_args.push(product_logging::framework::capture_shell_output(
             STACKABLE_LOG_DIR,
-            &Container::Prepare.to_string(),
+            Container::Prepare.name().as_ref(),
             log_config,
         ));
     }

--- a/rust/operator-binary/src/controller/build/resource/statefulset.rs
+++ b/rust/operator-binary/src/controller/build/resource/statefulset.rs
@@ -159,8 +159,8 @@ pub fn build_rolegroup_statefulset(
     let config_map_name = resource_names.role_group_config_map().to_string();
 
     let mut pod_builder = PodBuilder::new();
-    let mut cb_prepare = new_container_builder(&Container::Prepare);
-    let mut cb_trino = new_container_builder(&Container::Trino);
+    let mut cb_prepare = new_container_builder(Container::Prepare.name());
+    let mut cb_trino = new_container_builder(Container::Trino.name());
 
     // Operator-set env vars first; the user's `envOverrides` are merged on top last and win.
     let mut env = EnvVarSet::new();
@@ -396,7 +396,7 @@ pub fn build_rolegroup_statefulset(
 
     if let Some(vector_log_config) = &merged_config.logging.vector_container {
         pod_builder.add_container(vector_container(
-            &Container::Vector,
+            Container::Vector.name(),
             resolved_product_image,
             vector_log_config,
             &resource_names,

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -640,7 +640,7 @@ mod tests {
     }
 
     /// The typed container names returned by `name` must agree with the strum `Display` of
-    /// `Container`, which the rest of the operator still uses for log capture and container lookups.
+    /// `Container`, which operator-rs's `Logging<T>` requires and uses in error messages.
     #[test]
     fn container_names_match_display() {
         for container in Container::iter() {

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -469,10 +469,9 @@ constant!(VECTOR_CONTAINER_NAME: ContainerName = "vector");
 constant!(PASSWORD_FILE_UPDATER_CONTAINER_NAME: ContainerName = "password-file-updater");
 constant!(TRINO_CONTAINER_NAME: ContainerName = "trino");
 
-impl Deref for Container {
-    type Target = ContainerName;
-
-    fn deref(&self) -> &Self::Target {
+impl Container {
+    /// The typed container name of this variant.
+    pub fn name(&self) -> &'static ContainerName {
         match self {
             Container::Prepare => &PREPARE_CONTAINER_NAME,
             Container::Vector => &VECTOR_CONTAINER_NAME,
@@ -640,13 +639,12 @@ mod tests {
         let _ = *TRINO_CONTAINER_NAME;
     }
 
-    /// The typed container names behind `Container`'s `Deref` must agree with its strum `Display`,
-    /// which the rest of the operator still uses for log capture and container lookups.
+    /// The typed container names returned by `name` must agree with the strum `Display` of
+    /// `Container`, which the rest of the operator still uses for log capture and container lookups.
     #[test]
     fn container_names_match_display() {
         for container in Container::iter() {
-            let container_name: &ContainerName = &container;
-            assert_eq!(container_name.to_string(), container.to_string());
+            assert_eq!(container.name().to_string(), container.to_string());
         }
     }
 


### PR DESCRIPTION
<!--
This file is automatically generated from the templates in stackabletech/operator-templating
DO NOT MANUALLY EDIT THIS FILE
-->

## Description

Part of https://github.com/stackabletech/issues/issues/883

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [x] Code contains useful comments
- [x] (Integration-)Test cases added
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
